### PR TITLE
Improve loading performance of large SVG files with rectangular clip paths

### DIFF
--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/ClipPath.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/ClipPath.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2021 Jannis Weis
+ * Copyright (c) 2021-2023 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -22,6 +22,7 @@
 package com.github.weisj.jsvg.nodes;
 
 import java.awt.*;
+import java.awt.geom.Area;
 import java.awt.geom.Rectangle2D;
 
 import org.jetbrains.annotations.NotNull;
@@ -79,9 +80,12 @@ public final class ClipPath extends ContainerNode implements ShapedContainer<SVG
         // Todo: Handle bounding-box stuff as well (i.e. combined stroke etc.)
         Shape shape = ShapedContainer.super.elementShape(context);
         if (clipPathUnits == UnitType.ObjectBoundingBox) {
-            return clipPathUnits.viewTransform(elementBounds).createTransformedShape(shape);
-        } else {
-            return shape;
+            shape = clipPathUnits.viewTransform(elementBounds).createTransformedShape(shape);
         }
+        Area areaShape = new Area(shape);
+        if (areaShape.isRectangular()) {
+            return areaShape.getBounds();
+        }
+        return areaShape;
     }
 }

--- a/jsvg/src/main/java/com/github/weisj/jsvg/renderer/ShapeRenderer.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/renderer/ShapeRenderer.java
@@ -108,29 +108,36 @@ public final class ShapeRenderer {
         VectorEffect.applyEffects(shapePaintContext.vectorEffects, g,
                 shapePaintContext.context, shapePaintContext.transform);
 
+        Composite originalComposite = g.getComposite();
+        Paint originalPaint = g.getPaint();
+        Stroke originalStroke = g.getStroke();
+        AffineTransform originalTransform = g.getTransform();
+
         for (PaintOrder.Phase phase : paintOrder.phases()) {
-            Graphics2D phaseGraphics = (Graphics2D) g.create();
             RenderContext phaseContext = shapePaintContext.context.deriveForChildGraphics();
             switch (phase) {
                 case FILL:
                     if (canBeFilledHint) {
-                        ShapeRenderer.renderShapeFill(phaseContext, phaseGraphics, paintShape);
+                        ShapeRenderer.renderShapeFill(phaseContext, g, paintShape);
                     }
                     break;
                 case STROKE:
                     Shape strokeShape = paintShape.shape;
                     if (vectorEffects.contains(VectorEffect.NonScalingStroke)
                             && !vectorEffects.contains(VectorEffect.NonScalingSize)) {
-                        strokeShape = VectorEffect.applyNonScalingStroke(phaseGraphics, phaseContext, strokeShape);
+                        strokeShape = VectorEffect.applyNonScalingStroke(g, phaseContext, strokeShape);
                     }
-                    ShapeRenderer.renderShapeStroke(phaseContext, phaseGraphics,
+                    ShapeRenderer.renderShapeStroke(phaseContext, g,
                             new PaintShape(strokeShape, paintShape.bounds), shapePaintContext.stroke);
                     break;
                 case MARKERS:
-                    if (markerInfo != null) renderMarkers(phaseGraphics, phaseContext, paintShape, markerInfo);
+                    if (markerInfo != null) renderMarkers(g, phaseContext, paintShape, markerInfo);
                     break;
             }
-            phaseGraphics.dispose();
+            g.setComposite(originalComposite);
+            g.setPaint(originalPaint);
+            g.setStroke(originalStroke);
+            g.setTransform(originalTransform);
         }
     }
 

--- a/jsvg/src/main/java/com/github/weisj/jsvg/renderer/ShapeRenderer.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/renderer/ShapeRenderer.java
@@ -39,7 +39,7 @@ import com.github.weisj.jsvg.attributes.paint.SVGPaint;
 import com.github.weisj.jsvg.geometry.size.FloatSize;
 import com.github.weisj.jsvg.nodes.Marker;
 import com.github.weisj.jsvg.nodes.ShapeNode;
-import com.github.weisj.jsvg.util.ResettableGraphicsHolder;
+import com.github.weisj.jsvg.util.GraphicsResetHelper;
 
 public final class ShapeRenderer {
     private static final boolean DEBUG_MARKERS = false;
@@ -108,14 +108,14 @@ public final class ShapeRenderer {
         Set<VectorEffect> vectorEffects = shapePaintContext.vectorEffects;
         VectorEffect.applyEffects(shapePaintContext.vectorEffects, g,
                 shapePaintContext.context, shapePaintContext.transform);
-        ResettableGraphicsHolder holder = new ResettableGraphicsHolder(g);
+        GraphicsResetHelper resetHelper = new GraphicsResetHelper(g);
 
         for (PaintOrder.Phase phase : paintOrder.phases()) {
             RenderContext phaseContext = shapePaintContext.context.deriveForChildGraphics();
             switch (phase) {
                 case FILL:
                     if (canBeFilledHint) {
-                        ShapeRenderer.renderShapeFill(phaseContext, holder.getGraphics(), paintShape);
+                        ShapeRenderer.renderShapeFill(phaseContext, resetHelper.graphics(), paintShape);
                     }
                     break;
                 case STROKE:
@@ -123,16 +123,16 @@ public final class ShapeRenderer {
                     if (vectorEffects.contains(VectorEffect.NonScalingStroke)
                             && !vectorEffects.contains(VectorEffect.NonScalingSize)) {
                         strokeShape =
-                                VectorEffect.applyNonScalingStroke(holder.getGraphics(), phaseContext, strokeShape);
+                                VectorEffect.applyNonScalingStroke(resetHelper.graphics(), phaseContext, strokeShape);
                     }
-                    ShapeRenderer.renderShapeStroke(phaseContext, holder.getGraphics(),
+                    ShapeRenderer.renderShapeStroke(phaseContext, resetHelper.graphics(),
                             new PaintShape(strokeShape, paintShape.bounds), shapePaintContext.stroke);
                     break;
                 case MARKERS:
-                    if (markerInfo != null) renderMarkers(holder.getGraphics(), phaseContext, paintShape, markerInfo);
+                    if (markerInfo != null) renderMarkers(resetHelper.graphics(), phaseContext, paintShape, markerInfo);
                     break;
             }
-            holder.reset();
+            resetHelper.reset();
         }
     }
 

--- a/jsvg/src/main/java/com/github/weisj/jsvg/util/GraphicsResetHelper.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/util/GraphicsResetHelper.java
@@ -31,7 +31,7 @@ import java.awt.geom.AffineTransform;
  * This class does not track what parameters have been modified, nor does it reset all configuration parameters. Which
  * parameters are reset should be expanded as needed.
  */
-public class ResettableGraphicsHolder {
+public class GraphicsResetHelper {
 
     private final Graphics2D graphics;
 
@@ -40,7 +40,7 @@ public class ResettableGraphicsHolder {
     private final Stroke originalStroke;
     private final AffineTransform originalTransform;
 
-    public ResettableGraphicsHolder(Graphics2D graphics) {
+    public GraphicsResetHelper(Graphics2D graphics) {
         this.graphics = graphics;
 
         originalComposite = graphics.getComposite();
@@ -49,7 +49,7 @@ public class ResettableGraphicsHolder {
         originalTransform = graphics.getTransform();
     }
 
-    public Graphics2D getGraphics() {
+    public Graphics2D graphics() {
         return graphics;
     }
 

--- a/jsvg/src/main/java/com/github/weisj/jsvg/util/ResettableGraphicsHolder.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/util/ResettableGraphicsHolder.java
@@ -1,0 +1,62 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Jannis Weis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package com.github.weisj.jsvg.util;
+
+import java.awt.*;
+import java.awt.geom.AffineTransform;
+
+/**
+ * A utility class that holds a {@link Graphics2D} object and is able to reset it back to its original configuration,
+ * as this is often more efficient than creating a new graphics instance.
+ *
+ * This class does not track what parameters have been modified, nor does it reset all configuration parameters. Which
+ * parameters are reset should be expanded as needed.
+ */
+public class ResettableGraphicsHolder {
+
+    private final Graphics2D graphics;
+
+    private final Composite originalComposite;
+    private final Paint originalPaint;
+    private final Stroke originalStroke;
+    private final AffineTransform originalTransform;
+
+    public ResettableGraphicsHolder(Graphics2D graphics) {
+        this.graphics = graphics;
+
+        originalComposite = graphics.getComposite();
+        originalPaint = graphics.getPaint();
+        originalStroke = graphics.getStroke();
+        originalTransform = graphics.getTransform();
+    }
+
+    public Graphics2D getGraphics() {
+        return graphics;
+    }
+
+    public void reset() {
+        graphics.setComposite(originalComposite);
+        graphics.setPaint(originalPaint);
+        graphics.setStroke(originalStroke);
+        graphics.setTransform(originalTransform);
+    }
+}


### PR DESCRIPTION
- The SunGraphics2D implementation is more efficient when a Rectangle is used for the clip path
- Reducing the number of Graphics2D objects created aids with performance

This is in relation to #49 

For the changes in `ShapeRenderer`, there are more sophisticated ways to do it, but this seems to do the trick. The `Graphics2D` object passed is also modified in terms of clip, but this is already reset afterwards, and translate, but this should be handled by resetting the transform.

I created a repository where I did some tests, comparing the rendering time of some sample SVGs I found, before and after my changes: 

https://github.com/eriklumme1/jsvg-performance-test/blob/main/src/test/java/JsvgRenderTest.java
SVGs can be found in the test resources folder.

| File | Render before (ms) | Render after (ms) |
| --- | --- | --- |
| android.svg | 2.1 | 1.8 |
| gallardo.svg | 256 | 283 |
| islands.svg | 189 | 187 |
| micelle.svg | 270 | 233 |
| pencil.svg | 4.5 | 4.6 |
| propane.svg | 16  | 13  |
| venus.svg | 0.22 | 0.25 |
| world.svg | 4461 | 361 |

Performance is mostly the same, but the `world.svg` showed similar gains to the file that prompted me to create the issue.

I also did checksums of the generated PNG's before and after, they are different in two files. The first one is the gallardo.svg, where it looks different on the top side of the bumper. This is the only place where there are differences.

Before changes
![old-gallardo](https://github.com/weisJ/jsvg/assets/141633336/a2d1d144-3c05-44a6-a9de-8164b07e4e63)
After changes
![new-gallardo](https://github.com/weisJ/jsvg/assets/141633336/52b74f5a-7feb-4834-91e7-df1b83ceb407)
SVG in Chrome
![chrome-gallardo](https://github.com/weisJ/jsvg/assets/141633336/1240a6e8-8208-481b-9e9d-789cf2bf994d)

The other one is the world.svg, where only a bottom border is displayed differently. This might be an improvement.

Before changes
![old-world](https://github.com/weisJ/jsvg/assets/141633336/8cec6f34-957b-4bfd-97a0-c87f790563b2)
After changes
![new-world](https://github.com/weisJ/jsvg/assets/141633336/3638ae33-c16c-43da-bec7-6311daa45285)
SVG in Chrome
![chrome-world](https://github.com/weisJ/jsvg/assets/141633336/b4fa5b41-5953-4493-b62f-f7fc8f222f95)

I also had to remove one SVG that did not render with either version, although it rendered with 1.0.0. I'll make an issue for that.

Please let me know any concerns you have.