### PR TITLE
BlittableImage.java make image dimensions absolute and min 1

### DIFF
--- a/jsvg/src/main/java/com/github/weisj/jsvg/util/BlittableImage.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/util/BlittableImage.java
@@ -77,8 +77,11 @@ public final class BlittableImage {
 
         int imgX = (int) Math.floor(boundsInRootSpace.getX());
         int imgY = (int) Math.floor(boundsInRootSpace.getY());
-        int imgWidth = (int) Math.ceil(boundsInRootSpace.getX() + boundsInRootSpace.getWidth()) - imgX;
-        int imgHeight = (int) Math.ceil(boundsInRootSpace.getY() + boundsInRootSpace.getHeight()) - imgY;
+
+        int imgWidth =
+                Math.max(Math.abs((int) Math.ceil(boundsInRootSpace.getX() + boundsInRootSpace.getWidth()) - imgX), 1);
+        int imgHeight =
+                Math.max(Math.abs((int) Math.ceil(boundsInRootSpace.getY() + boundsInRootSpace.getHeight()) - imgY), 1);
 
         Rectangle2D adjustedUserSpaceBounds = new Rectangle2D.Double(imgX, imgY, imgWidth, imgHeight);
         try {


### PR DESCRIPTION
fix calculated image dimensions always positive and min 1
![gallardo](https://github.com/weisJ/jsvg/assets/1221874/8dee8d1b-9a8e-46d8-9d56-b2fd15a8daf0)

attached file does not render before this patch 