### PR TITLE
Add API to compute the shape of an SVGDocument

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021-2022 Jannis Weis
+Copyright (c) 2021-2024 Jannis Weis
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -112,6 +112,7 @@ allprojects {
             }
             format("svg") {
                 target("**/*.svg")
+                targetExclude("**/brokenUpCharContent.svg")
                 eclipseWtp(EclipseWtpFormatterStep.XML)
             }
             plugins.withType<JavaPlugin>().configureEach {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -297,7 +297,7 @@ allprojects {
                         )
                         name.set(
                             (project.findProperty("artifact.name") as? String)
-                                ?: project.name.capitalize().replace("-", " ")
+                                ?: project.name.replaceFirstChar { it.uppercase() }.replace("-", " ")
                         )
                         url.set("https://github.com/weisJ/jsvg")
                         organization {

--- a/jsvg/src/main/java/com/github/weisj/jsvg/SVGDocument.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/SVGDocument.java
@@ -22,14 +22,11 @@
 package com.github.weisj.jsvg;
 
 import java.awt.*;
+import java.awt.geom.Path2D;
 import java.util.Objects;
-import java.util.Optional;
 
 import javax.swing.*;
 
-import com.github.weisj.jsvg.nodes.View;
-import com.github.weisj.jsvg.renderer.Graphics2DOutput;
-import com.github.weisj.jsvg.renderer.Output;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -38,8 +35,7 @@ import com.github.weisj.jsvg.attributes.font.SVGFont;
 import com.github.weisj.jsvg.geometry.size.FloatSize;
 import com.github.weisj.jsvg.geometry.size.MeasureContext;
 import com.github.weisj.jsvg.nodes.SVG;
-import com.github.weisj.jsvg.renderer.NodeRenderer;
-import com.github.weisj.jsvg.renderer.RenderContext;
+import com.github.weisj.jsvg.renderer.*;
 import com.github.weisj.jsvg.renderer.awt.JComponentPlatformSupport;
 import com.github.weisj.jsvg.renderer.awt.NullPlatformSupport;
 import com.github.weisj.jsvg.renderer.awt.PlatformSupport;
@@ -64,14 +60,9 @@ public final class SVGDocument {
     }
 
     public @NotNull Shape computeShape(@Nullable ViewBox viewBox) {
-        Output output = null;
-        RenderContext context = prepareRenderContext(new NullPlatformSupport(), output, viewBox);
-        Shape shape = root.elementShape(context);
-        if (viewBox != null) {
-            System.out.println(context.userSpaceTransform());
-            shape = context.userSpaceTransform().createTransformedShape(shape);
-        }
-        return shape;
+        Path2D accumulator = new Path2D.Float();
+        renderWithPlatform(new NullPlatformSupport(), new ShapeOutput(accumulator), viewBox);
+        return accumulator;
     }
 
     public void render(@Nullable JComponent component, @NotNull Graphics2D g) {

--- a/jsvg/src/main/java/com/github/weisj/jsvg/SVGDocument.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/SVGDocument.java
@@ -22,6 +22,7 @@
 package com.github.weisj.jsvg;
 
 import java.awt.*;
+import java.awt.geom.Area;
 import java.awt.geom.Path2D;
 import java.util.Objects;
 
@@ -60,7 +61,7 @@ public final class SVGDocument {
     }
 
     public @NotNull Shape computeShape(@Nullable ViewBox viewBox) {
-        Path2D accumulator = new Path2D.Float();
+        Area accumulator = new Area(new Path2D.Float());
         renderWithPlatform(new NullPlatformSupport(), new ShapeOutput(accumulator), viewBox);
         return accumulator;
     }

--- a/jsvg/src/main/java/com/github/weisj/jsvg/attributes/VectorEffect.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/attributes/VectorEffect.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2023 Jannis Weis
+ * Copyright (c) 2022-2024 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -30,6 +30,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import com.github.weisj.jsvg.parser.AttributeNode;
+import com.github.weisj.jsvg.renderer.Output;
 import com.github.weisj.jsvg.renderer.RenderContext;
 
 
@@ -76,7 +77,7 @@ public enum VectorEffect implements HasMatchName {
         return flag;
     }
 
-    public static void applyEffects(@NotNull Set<VectorEffect> effects, @NotNull Graphics2D g,
+    public static void applyEffects(@NotNull Set<VectorEffect> effects, @NotNull Output output,
             @NotNull RenderContext context, @Nullable AffineTransform elementTransform) {
         int flags = flags(effects);
         if (flags == 0) return;
@@ -88,15 +89,15 @@ public enum VectorEffect implements HasMatchName {
 
         updateTransformForFlags(flags, shapeTransform, x0, y0);
 
-        g.setTransform(context.rootTransform());
-        g.transform(shapeTransform);
+        output.setTransform(context.rootTransform());
+        output.applyTransform(shapeTransform);
     }
 
-    public static @NotNull Shape applyNonScalingStroke(@NotNull Graphics2D g, @NotNull RenderContext context,
+    public static @NotNull Shape applyNonScalingStroke(@NotNull Output output, @NotNull RenderContext context,
             @NotNull Shape shape) {
         // For the stroke not to be scaled we have to pre-multiply the shape by the transform and then paint
         // in the non-transformed coordinate system.
-        g.setTransform(context.rootTransform());
+        output.setTransform(context.rootTransform());
         return context.userSpaceTransform().createTransformedShape(shape);
     }
 

--- a/jsvg/src/main/java/com/github/weisj/jsvg/attributes/paint/SVGPaint.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/attributes/paint/SVGPaint.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2021-2023 Jannis Weis
+ * Copyright (c) 2021-2024 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -27,17 +27,18 @@ import java.awt.geom.Rectangle2D;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import com.github.weisj.jsvg.renderer.Output;
 import com.github.weisj.jsvg.renderer.RenderContext;
 
 public interface SVGPaint {
     AwtSVGPaint DEFAULT_PAINT = new AwtSVGPaint(PaintParser.DEFAULT_COLOR);
     SVGPaint NONE = new SVGPaint() {
         @Override
-        public void fillShape(@NotNull Graphics2D g, @NotNull RenderContext context, @NotNull Shape shape,
+        public void fillShape(@NotNull Output output, @NotNull RenderContext context, @NotNull Shape shape,
                 @Nullable Rectangle2D bounds) { /* NONE shouldn't fill anything */ }
 
         @Override
-        public void drawShape(@NotNull Graphics2D g, @NotNull RenderContext context, @NotNull Shape shape,
+        public void drawShape(@NotNull Output output, @NotNull RenderContext context, @NotNull Shape shape,
                 @Nullable Rectangle2D bounds) { /* NONE shouldn't draw anything */ }
 
         @Override
@@ -47,13 +48,13 @@ public interface SVGPaint {
     };
     SVGPaint CURRENT_COLOR = new SVGPaint() {
         @Override
-        public void fillShape(@NotNull Graphics2D g, @NotNull RenderContext context, @NotNull Shape shape,
+        public void fillShape(@NotNull Output output, @NotNull RenderContext context, @NotNull Shape shape,
                 @Nullable Rectangle2D bounds) {
             throw new IllegalStateException("Sentinel color CURRENT_COLOR shouldn't be used for painting directly");
         }
 
         @Override
-        public void drawShape(@NotNull Graphics2D g, @NotNull RenderContext context, @NotNull Shape shape,
+        public void drawShape(@NotNull Output output, @NotNull RenderContext context, @NotNull Shape shape,
                 @Nullable Rectangle2D bounds) {
             throw new IllegalStateException("Sentinel color CURRENT_COLOR shouldn't be used for painting directly");
         }
@@ -65,13 +66,13 @@ public interface SVGPaint {
     };
     SVGPaint CONTEXT_FILL = new SVGPaint() {
         @Override
-        public void fillShape(@NotNull Graphics2D g, @NotNull RenderContext context, @NotNull Shape shape,
+        public void fillShape(@NotNull Output output, @NotNull RenderContext context, @NotNull Shape shape,
                 @Nullable Rectangle2D bounds) {
             throw new IllegalStateException("Sentinel color CONTEXT_FILL shouldn't be used for painting directly");
         }
 
         @Override
-        public void drawShape(@NotNull Graphics2D g, @NotNull RenderContext context, @NotNull Shape shape,
+        public void drawShape(@NotNull Output output, @NotNull RenderContext context, @NotNull Shape shape,
                 @Nullable Rectangle2D bounds) {
             throw new IllegalStateException("Sentinel color CONTEXT_FILL shouldn't be used for painting directly");
         }
@@ -83,13 +84,13 @@ public interface SVGPaint {
     };
     SVGPaint CONTEXT_STROKE = new SVGPaint() {
         @Override
-        public void fillShape(@NotNull Graphics2D g, @NotNull RenderContext context, @NotNull Shape shape,
+        public void fillShape(@NotNull Output output, @NotNull RenderContext context, @NotNull Shape shape,
                 @Nullable Rectangle2D bounds) {
             throw new IllegalStateException("Sentinel color CONTEXT_STROKE shouldn't be used for painting directly");
         }
 
         @Override
-        public void drawShape(@NotNull Graphics2D g, @NotNull RenderContext context, @NotNull Shape shape,
+        public void drawShape(@NotNull Output output, @NotNull RenderContext context, @NotNull Shape shape,
                 @Nullable Rectangle2D bounds) {
             throw new IllegalStateException("Sentinel color CONTEXT_STROKE shouldn't be used for painting directly");
         }
@@ -100,10 +101,10 @@ public interface SVGPaint {
         }
     };
 
-    void fillShape(@NotNull Graphics2D g, @NotNull RenderContext context, @NotNull Shape shape,
+    void fillShape(@NotNull Output output, @NotNull RenderContext context, @NotNull Shape shape,
             @Nullable Rectangle2D bounds);
 
-    void drawShape(@NotNull Graphics2D g, @NotNull RenderContext context, @NotNull Shape shape,
+    void drawShape(@NotNull Output output, @NotNull RenderContext context, @NotNull Shape shape,
             @Nullable Rectangle2D bounds);
 
     default boolean isVisible() {

--- a/jsvg/src/main/java/com/github/weisj/jsvg/attributes/paint/SimplePaintSVGPaint.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/attributes/paint/SimplePaintSVGPaint.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2021-2023 Jannis Weis
+ * Copyright (c) 2021-2024 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -27,7 +27,7 @@ import java.awt.geom.Rectangle2D;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import com.github.weisj.jsvg.renderer.GraphicsUtil;
+import com.github.weisj.jsvg.renderer.Output;
 import com.github.weisj.jsvg.renderer.RenderContext;
 
 public interface SimplePaintSVGPaint extends SVGPaint {
@@ -36,16 +36,16 @@ public interface SimplePaintSVGPaint extends SVGPaint {
     Paint paint();
 
     @Override
-    default void fillShape(@NotNull Graphics2D g, @NotNull RenderContext context, @NotNull Shape shape,
+    default void fillShape(@NotNull Output output, @NotNull RenderContext context, @NotNull Shape shape,
             @Nullable Rectangle2D bounds) {
-        GraphicsUtil.safelySetPaint(g, paint());
-        g.fill(shape);
+        output.setPaint(paint());
+        output.fillShape(shape);
     }
 
     @Override
-    default void drawShape(@NotNull Graphics2D g, @NotNull RenderContext context, @NotNull Shape shape,
+    default void drawShape(@NotNull Output output, @NotNull RenderContext context, @NotNull Shape shape,
             @Nullable Rectangle2D bounds) {
-        GraphicsUtil.safelySetPaint(g, paint());
-        g.draw(shape);
+        output.setPaint(paint());
+        output.drawShape(shape);
     }
 }

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/AbstractGradient.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/AbstractGradient.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2021-2023 Jannis Weis
+ * Copyright (c) 2021-2024 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -37,7 +37,7 @@ import com.github.weisj.jsvg.attributes.paint.SVGPaint;
 import com.github.weisj.jsvg.geometry.size.MeasureContext;
 import com.github.weisj.jsvg.nodes.container.ContainerNode;
 import com.github.weisj.jsvg.parser.AttributeNode;
-import com.github.weisj.jsvg.renderer.GraphicsUtil;
+import com.github.weisj.jsvg.renderer.Output;
 import com.github.weisj.jsvg.renderer.RenderContext;
 
 @SuppressWarnings("java:S119") // Generic name Self is intentional
@@ -181,19 +181,19 @@ abstract class AbstractGradient<Self extends AbstractGradient<Self>> extends Con
     protected abstract void buildGradient(@NotNull AttributeNode attributeNode, @Nullable Self template);
 
     @Override
-    public void fillShape(@NotNull Graphics2D g, @NotNull RenderContext context, @NotNull Shape shape,
+    public void fillShape(@NotNull Output output, @NotNull RenderContext context, @NotNull Shape shape,
             @Nullable Rectangle2D bounds) {
         Rectangle2D b = bounds != null ? bounds : shape.getBounds2D();
-        GraphicsUtil.safelySetPaint(g, paintForBounds(context.measureContext(), b));
-        g.fill(shape);
+        output.setPaint(paintForBounds(context.measureContext(), b));
+        output.fillShape(shape);
     }
 
     @Override
-    public void drawShape(@NotNull Graphics2D g, @NotNull RenderContext context, @NotNull Shape shape,
+    public void drawShape(@NotNull Output output, @NotNull RenderContext context, @NotNull Shape shape,
             @Nullable Rectangle2D bounds) {
         Rectangle2D b = bounds != null ? bounds : shape.getBounds2D();
-        GraphicsUtil.safelySetPaint(g, paintForBounds(context.measureContext(), b));
-        g.draw(shape);
+        output.setPaint(paintForBounds(context.measureContext(), b));
+        output.drawShape(shape);
     }
 
     private @NotNull Paint paintForBounds(@NotNull MeasureContext context, @NotNull Rectangle2D bounds) {

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/AbstractGradient.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/AbstractGradient.java
@@ -184,7 +184,7 @@ abstract class AbstractGradient<Self extends AbstractGradient<Self>> extends Con
     public void fillShape(@NotNull Output output, @NotNull RenderContext context, @NotNull Shape shape,
             @Nullable Rectangle2D bounds) {
         Rectangle2D b = bounds != null ? bounds : shape.getBounds2D();
-        output.setPaint(paintForBounds(context.measureContext(), b));
+        output.setPaint(() -> paintForBounds(context.measureContext(), b));
         output.fillShape(shape);
     }
 
@@ -192,7 +192,7 @@ abstract class AbstractGradient<Self extends AbstractGradient<Self>> extends Con
     public void drawShape(@NotNull Output output, @NotNull RenderContext context, @NotNull Shape shape,
             @Nullable Rectangle2D bounds) {
         Rectangle2D b = bounds != null ? bounds : shape.getBounds2D();
-        output.setPaint(paintForBounds(context.measureContext(), b));
+        output.setPaint(() -> paintForBounds(context.measureContext(), b));
         output.drawShape(shape);
     }
 

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/Image.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/Image.java
@@ -21,7 +21,6 @@
  */
 package com.github.weisj.jsvg.nodes;
 
-import java.awt.*;
 import java.awt.geom.AffineTransform;
 import java.io.IOException;
 import java.net.URI;

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/Image.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/Image.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2021-2023 Jannis Weis
+ * Copyright (c) 2021-2024 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -46,6 +46,7 @@ import com.github.weisj.jsvg.parser.UIFuture;
 import com.github.weisj.jsvg.parser.ValueUIFuture;
 import com.github.weisj.jsvg.parser.resources.MissingImageResource;
 import com.github.weisj.jsvg.parser.resources.RenderableResource;
+import com.github.weisj.jsvg.renderer.Output;
 import com.github.weisj.jsvg.renderer.RenderContext;
 
 @ElementCategories({Category.Graphic, Category.GraphicsReferencing})
@@ -108,7 +109,7 @@ public final class Image extends RenderableSVGNode {
     }
 
     @Override
-    public void render(@NotNull RenderContext context, @NotNull Graphics2D g) {
+    public void render(@NotNull RenderContext context, @NotNull Output output) {
         RenderableResource resource = fetchImage(context);
         if (resource == null) {
             resource = new MissingImageResource();
@@ -123,15 +124,15 @@ public final class Image extends RenderableSVGNode {
         float viewWidth = width.orElseIfUnspecified(resourceWidth).resolveWidth(measure);
         float viewHeight = height.orElseIfUnspecified(resourceHeight).resolveHeight(measure);
 
-        g.translate(x.resolveWidth(measure), y.resolveHeight(measure));
+        output.translate(x.resolveWidth(measure), y.resolveHeight(measure));
 
-        if (overflow.establishesClip()) g.clip(new ViewBox(viewWidth, viewHeight));
+        if (overflow.establishesClip()) output.applyClip(new ViewBox(viewWidth, viewHeight));
         // Todo: Vector Effects
 
         AffineTransform imgTransform = preserveAspectRatio.computeViewPortTransform(
                 new FloatSize(viewWidth, viewHeight),
                 new ViewBox(resourceWidth, resourceHeight));
 
-        resource.render(g, context, imgTransform);
+        resource.render(output, context, imgTransform);
     }
 }

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/Pattern.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/Pattern.java
@@ -142,7 +142,8 @@ public final class Pattern extends BaseInnerViewContainer implements SVGPaint, S
     public void fillShape(@NotNull Output output, @NotNull RenderContext context, @NotNull Shape shape,
             @Nullable Rectangle2D bounds) {
         Rectangle2D b = bounds != null ? bounds : shape.getBounds2D();
-        output.setPaint(paintForBounds(output, context, b));
+        // TODO: Might not fully want to avoid this here if shape computation should become more fine grained.
+        output.setPaint(() -> paintForBounds(output, context, b));
         output.fillShape(shape);
     }
 
@@ -150,7 +151,7 @@ public final class Pattern extends BaseInnerViewContainer implements SVGPaint, S
     public void drawShape(@NotNull Output output, @NotNull RenderContext context, @NotNull Shape shape,
             @Nullable Rectangle2D bounds) {
         Rectangle2D b = bounds != null ? bounds : shape.getBounds2D();
-        output.setPaint(paintForBounds(output, context, b));
+        output.setPaint(() -> paintForBounds(output, context, b));
         output.drawShape(shape);
     }
 

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/Pattern.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/Pattern.java
@@ -142,7 +142,8 @@ public final class Pattern extends BaseInnerViewContainer implements SVGPaint, S
     public void fillShape(@NotNull Output output, @NotNull RenderContext context, @NotNull Shape shape,
             @Nullable Rectangle2D bounds) {
         Rectangle2D b = bounds != null ? bounds : shape.getBounds2D();
-        // TODO: Might not fully want to avoid this here if shape computation should become more fine grained.
+        // TODO: Might not fully want to avoid this here if shape computation should become more fine
+        // grained.
         output.setPaint(() -> paintForBounds(output, context, b));
         output.fillShape(shape);
     }

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/ShapeNode.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/ShapeNode.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2021-2023 Jannis Weis
+ * Copyright (c) 2021-2024 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -38,6 +38,7 @@ import com.github.weisj.jsvg.geometry.size.Length;
 import com.github.weisj.jsvg.geometry.size.MeasureContext;
 import com.github.weisj.jsvg.nodes.prototype.*;
 import com.github.weisj.jsvg.parser.AttributeNode;
+import com.github.weisj.jsvg.renderer.Output;
 import com.github.weisj.jsvg.renderer.PaintContext;
 import com.github.weisj.jsvg.renderer.RenderContext;
 import com.github.weisj.jsvg.renderer.ShapeRenderer;
@@ -141,14 +142,14 @@ public abstract class ShapeNode extends RenderableSVGNode
     }
 
     @Override
-    public final void render(@NotNull RenderContext context, @NotNull Graphics2D g) {
+    public final void render(@NotNull RenderContext context, @NotNull Output output) {
         Shape paintShape = shape.shape(context);
         @Nullable Rectangle2D bounds = shape.usesOptimizedBoundsCalculation()
                 ? shape.bounds(context, false)
                 : null;
 
         Stroke effectiveStroke = computeEffectiveStroke(context);
-        ShapeRenderer.renderWithPaintOrder(g, shape.canBeFilled(), paintOrder,
+        ShapeRenderer.renderWithPaintOrder(output, shape.canBeFilled(), paintOrder,
                 new ShapeRenderer.ShapePaintContext(context, vectorEffects(), effectiveStroke, transform()),
                 new ShapeRenderer.PaintShape(paintShape, bounds),
                 new ShapeRenderer.ShapeMarkerInfo(this, markerStart, markerMid, markerEnd,

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/Use.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/Use.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2021-2023 Jannis Weis
+ * Copyright (c) 2021-2024 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -139,23 +139,23 @@ public final class Use extends RenderableSVGNode implements HasContext, HasShape
     }
 
     @Override
-    public void render(@NotNull RenderContext context, @NotNull Graphics2D g) {
+    public void render(@NotNull RenderContext context, @NotNull Output output) {
         if (referencedNode != null) {
             MeasureContext measureContext = context.measureContext();
-            context.translate(g, x.resolveWidth(measureContext), y.resolveHeight(measureContext));
+            context.translate(output, x.resolveWidth(measureContext), y.resolveHeight(measureContext));
 
             // Todo: Vector Effects
 
-            try (NodeRenderer.Info info = NodeRenderer.createRenderInfo(referencedNode, context, g, this)) {
+            try (NodeRenderer.Info info = NodeRenderer.createRenderInfo(referencedNode, context, output, this)) {
                 if (info == null) return;
                 if (referencedNode instanceof CommonInnerViewContainer) {
                     FloatSize targetViewBox = new FloatSize(Length.UNSPECIFIED_RAW, Length.UNSPECIFIED_RAW);
                     if (width.isSpecified()) targetViewBox.width = width.resolveWidth(measureContext);
                     if (height.isSpecified()) targetViewBox.height = height.resolveHeight(measureContext);
                     CommonInnerViewContainer view = (CommonInnerViewContainer) referencedNode;
-                    view.renderWithSize(targetViewBox, view.viewBox(info.context), info.context, info.graphics());
+                    view.renderWithSize(targetViewBox, view.viewBox(info.context), info.context, info.output());
                 } else {
-                    info.renderable.render(info.context, info.graphics());
+                    info.renderable.render(info.context, info.output());
                 }
             }
         }

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/container/CommonRenderableContainerNode.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/container/CommonRenderableContainerNode.java
@@ -21,7 +21,6 @@
  */
 package com.github.weisj.jsvg.nodes.container;
 
-import java.awt.*;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/container/CommonRenderableContainerNode.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/container/CommonRenderableContainerNode.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2021-2022 Jannis Weis
+ * Copyright (c) 2021-2024 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -36,6 +36,7 @@ import com.github.weisj.jsvg.nodes.prototype.impl.HasContextImpl;
 import com.github.weisj.jsvg.nodes.prototype.impl.HasGeometryContextImpl;
 import com.github.weisj.jsvg.parser.AttributeNode;
 import com.github.weisj.jsvg.renderer.NodeRenderer;
+import com.github.weisj.jsvg.renderer.Output;
 import com.github.weisj.jsvg.renderer.RenderContext;
 
 public abstract class CommonRenderableContainerNode extends BaseContainerNode<SVGNode>
@@ -76,9 +77,9 @@ public abstract class CommonRenderableContainerNode extends BaseContainerNode<SV
     }
 
     @Override
-    public void render(@NotNull RenderContext context, @NotNull Graphics2D g) {
+    public void render(@NotNull RenderContext context, @NotNull Output output) {
         for (SVGNode child : children()) {
-            NodeRenderer.renderNode(child, context, g);
+            NodeRenderer.renderNode(child, context, output);
         }
     }
 

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/FeFlood.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/FeFlood.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2023 Jannis Weis
+ * Copyright (c) 2022-2024 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -36,6 +36,7 @@ import com.github.weisj.jsvg.nodes.prototype.spec.Category;
 import com.github.weisj.jsvg.nodes.prototype.spec.ElementCategories;
 import com.github.weisj.jsvg.nodes.prototype.spec.PermittedContent;
 import com.github.weisj.jsvg.parser.AttributeNode;
+import com.github.weisj.jsvg.renderer.Graphics2DOutput;
 import com.github.weisj.jsvg.renderer.GraphicsUtil;
 import com.github.weisj.jsvg.renderer.RenderContext;
 
@@ -79,7 +80,7 @@ public final class FeFlood extends AbstractFilterPrimitive {
             Graphics2D graphics = GraphicsUtil.createGraphics(img);
             graphics.setComposite(AlphaComposite.Src.derive(floodOpacity));
             Rectangle rect = new Rectangle(0, 0, img.getWidth(), img.getHeight());
-            floodColor.fillShape(graphics, context, rect, rect);
+            floodColor.fillShape(new Graphics2DOutput(graphics), context, rect, rect);
             graphics.dispose();
         }
         impl().saveResult(new ImageProducerChannel(img.getSource()), filterContext);

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/FeGaussianBlur.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/FeGaussianBlur.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2021-2023 Jannis Weis
+ * Copyright (c) 2021-2024 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -100,7 +100,7 @@ public final class FeGaussianBlur extends AbstractFilterPrimitive {
             return;
         }
 
-        double[] sigma = computeAbsoluteStdDeviation(filterContext.info().graphics().getTransform());
+        double[] sigma = computeAbsoluteStdDeviation(filterContext.info().output().transform());
         double xSigma = sigma[0];
         double ySigma = sigma[1];
 

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/FeOffset.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/FeOffset.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jannis Weis
+ * Copyright (c) 2023-2024 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -92,7 +92,7 @@ public final class FeOffset extends AbstractFilterPrimitive {
         Channel in = impl().inputChannel(filterContext);
         Channel result = in;
         if (dx != 0 || dy != 0) {
-            AffineTransform at = filterContext.info().graphics().getTransform();
+            AffineTransform at = filterContext.info().output().transform();
             Point2D.Double off = offset(at, filterContext.primitiveUnits(), filterContext.info().elementBounds());
             AffineTransform transform = AffineTransform.getTranslateInstance(off.x, off.y);
 

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/FilterContext.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/FilterContext.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2021-2023 Jannis Weis
+ * Copyright (c) 2021-2024 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -24,6 +24,7 @@ package com.github.weisj.jsvg.nodes.filter;
 import java.awt.*;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import com.github.weisj.jsvg.attributes.UnitType;
 import com.github.weisj.jsvg.attributes.filter.FilterChannelKey;
@@ -33,10 +34,10 @@ public final class FilterContext {
     private final @NotNull ChannelStorage<Channel> resultChannels = new ChannelStorage<>();
     private final Filter.FilterInfo info;
     private final @NotNull UnitType primitiveUnits;
-    private final @NotNull RenderingHints renderingHints;
+    private final @Nullable RenderingHints renderingHints;
 
     public FilterContext(@NotNull Filter.FilterInfo info, @NotNull UnitType primitiveUnits,
-            @NotNull RenderingHints renderingHints) {
+            @Nullable RenderingHints renderingHints) {
         this.info = info;
         this.primitiveUnits = primitiveUnits;
         this.renderingHints = renderingHints;
@@ -50,7 +51,7 @@ public final class FilterContext {
         return primitiveUnits;
     }
 
-    public @NotNull RenderingHints renderingHints() {
+    public @Nullable RenderingHints renderingHints() {
         return renderingHints;
     }
 

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/mesh/MeshGradient.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/mesh/MeshGradient.java
@@ -94,22 +94,22 @@ public final class MeshGradient extends ContainerNode implements SVGPaint {
     @Override
     public void fillShape(@NotNull Output output, @NotNull RenderContext context, @NotNull Shape shape,
             @Nullable Rectangle2D bounds) {
-        Shape clip = output.clip();
+        Output.SafeState safeState = output.safeState();
         Rectangle2D b = bounds != null ? bounds : shape.getBounds2D();
         output.setClip(shape);
         output.translate(b.getX(), b.getY());
         renderMesh(context.measureContext(), output);
-        output.setClip(clip);
+        safeState.restore();
     }
 
     @Override
     public void drawShape(@NotNull Output output, @NotNull RenderContext context, @NotNull Shape shape,
             @Nullable Rectangle2D bounds) {
-        Shape clip = output.clip();
+        Output.SafeState safeState = output.safeState();
         Rectangle2D b = bounds != null ? bounds : shape.getBounds2D();
         output.setClip(output.stroke().createStrokedShape(shape));
         output.translate(b.getX(), b.getY());
         renderMesh(context.measureContext(), output);
-        output.setClip(clip);
+        safeState.restore();
     }
 }

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/mesh/MeshGradient.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/mesh/MeshGradient.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2021-2023 Jannis Weis
+ * Copyright (c) 2021-2024 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -42,6 +42,7 @@ import com.github.weisj.jsvg.nodes.prototype.spec.ElementCategories;
 import com.github.weisj.jsvg.nodes.prototype.spec.NotImplemented;
 import com.github.weisj.jsvg.nodes.prototype.spec.PermittedContent;
 import com.github.weisj.jsvg.parser.AttributeNode;
+import com.github.weisj.jsvg.renderer.Output;
 import com.github.weisj.jsvg.renderer.RenderContext;
 
 @ElementCategories(Category.Gradient)
@@ -75,40 +76,40 @@ public final class MeshGradient extends ContainerNode implements SVGPaint {
         // Todo: transform
     }
 
-    public void renderMesh(@NotNull MeasureContext measure, @NotNull Graphics2D g) {
-        Graphics2D meshGraphics = (Graphics2D) g.create();
+    public void renderMesh(@NotNull MeasureContext measure, @NotNull Output output) {
+        Output meshOutput = output.createChild();
         // meshGraphics.translate(x.resolveWidth(measure), y.resolveHeight(measure));
 
-        meshGraphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_OFF);
+        meshOutput.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_OFF);
         for (SVGNode child : children()) {
             MeshRow row = (MeshRow) child;
             for (SVGNode node : row.children()) {
                 MeshPatch patch = (MeshPatch) node;
-                patch.renderPath(meshGraphics);
+                patch.renderPath(meshOutput);
             }
         }
-        meshGraphics.dispose();
+        meshOutput.dispose();
     }
 
     @Override
-    public void fillShape(@NotNull Graphics2D g, @NotNull RenderContext context, @NotNull Shape shape,
+    public void fillShape(@NotNull Output output, @NotNull RenderContext context, @NotNull Shape shape,
             @Nullable Rectangle2D bounds) {
-        Shape clip = g.getClip();
+        Shape clip = output.clip();
         Rectangle2D b = bounds != null ? bounds : shape.getBounds2D();
-        g.setClip(shape);
-        g.translate(b.getX(), b.getY());
-        renderMesh(context.measureContext(), g);
-        g.setClip(clip);
+        output.setClip(shape);
+        output.translate(b.getX(), b.getY());
+        renderMesh(context.measureContext(), output);
+        output.setClip(clip);
     }
 
     @Override
-    public void drawShape(@NotNull Graphics2D g, @NotNull RenderContext context, @NotNull Shape shape,
+    public void drawShape(@NotNull Output output, @NotNull RenderContext context, @NotNull Shape shape,
             @Nullable Rectangle2D bounds) {
-        Shape clip = g.getClip();
+        Shape clip = output.clip();
         Rectangle2D b = bounds != null ? bounds : shape.getBounds2D();
-        g.setClip(g.getStroke().createStrokedShape(shape));
-        g.translate(b.getX(), b.getY());
-        renderMesh(context.measureContext(), g);
-        g.setClip(clip);
+        output.setClip(output.stroke().createStrokedShape(shape));
+        output.translate(b.getX(), b.getY());
+        renderMesh(context.measureContext(), output);
+        output.setClip(clip);
     }
 }

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/mesh/MeshPatch.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/mesh/MeshPatch.java
@@ -60,6 +60,11 @@ public final class MeshPatch extends ContainerNode {
     }
 
     public void renderPath(@NotNull Output output) {
+        if (!output.supportsColors()) {
+            output.fillShape(coonPatch.toShape());
+            return;
+        }
+
         AffineTransform at = output.transform();
         float scaleX = (float) GeometryUtil.scaleYOfTransform(at);
         float scaleY = (float) GeometryUtil.scaleYOfTransform(at);

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/mesh/MeshPatch.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/mesh/MeshPatch.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2021 Jannis Weis
+ * Copyright (c) 2021-2024 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -37,7 +37,7 @@ import com.github.weisj.jsvg.nodes.container.ContainerNode;
 import com.github.weisj.jsvg.nodes.prototype.spec.Category;
 import com.github.weisj.jsvg.nodes.prototype.spec.ElementCategories;
 import com.github.weisj.jsvg.nodes.prototype.spec.PermittedContent;
-import com.github.weisj.jsvg.renderer.GraphicsUtil;
+import com.github.weisj.jsvg.renderer.Output;
 
 @ElementCategories({ /* None */})
 @PermittedContent(
@@ -59,8 +59,8 @@ public final class MeshPatch extends ContainerNode {
         return TAG;
     }
 
-    public void renderPath(@NotNull Graphics2D g) {
-        AffineTransform at = g.getTransform();
+    public void renderPath(@NotNull Output output) {
+        AffineTransform at = output.transform();
         float scaleX = (float) GeometryUtil.scaleYOfTransform(at);
         float scaleY = (float) GeometryUtil.scaleYOfTransform(at);
         int depth = Math.max(
@@ -68,10 +68,10 @@ public final class MeshPatch extends ContainerNode {
                         coonPatch.east.estimateStepCount(scaleX, scaleY)),
                 Math.max(coonPatch.south.estimateStepCount(scaleX, scaleY),
                         coonPatch.west.estimateStepCount(scaleX, scaleY)));
-        renderPath(g, coonPatch, scaleX, scaleY, Math.min(MAX_DEPTH, depth));
+        renderPath(output, coonPatch, scaleX, scaleY, Math.min(MAX_DEPTH, depth));
     }
 
-    private void renderPath(@NotNull Graphics2D g, @NotNull CoonPatch patch, float scaleX, float scaleY, int depth) {
+    private void renderPath(@NotNull Output output, @NotNull CoonPatch patch, float scaleX, float scaleY, int depth) {
         CoonValues weights = patch.coonValues;
         // Check if we have reached the limit of discernible colors. This happens if our color weights
         // spectrum allows for less that approximately (1/255)^3, which is our "relative color-depth".
@@ -79,15 +79,15 @@ public final class MeshPatch extends ContainerNode {
                 * GeometryUtil.distanceSquared(weights.east, weights.west, scaleX, scaleY) < 0.000001) {
             float u = (weights.north.x + weights.east.x + weights.south.x + weights.west.x) / 4;
             float v = (weights.north.y + weights.east.y + weights.south.y + weights.west.y) / 4;
-            GraphicsUtil.safelySetPaint(g, bilinearInterpolation(u, v));
+            output.setPaint(bilinearInterpolation(u, v));
             Shape s = patch.toShape();
-            g.fill(s.getBounds2D());
+            output.fillShape(s.getBounds2D());
         } else {
             Subdivided<CoonPatch> patchSubdivided = patch.subdivide();
-            renderPath(g, patchSubdivided.northWest, scaleX, scaleY, depth - 1);
-            renderPath(g, patchSubdivided.northEast, scaleX, scaleY, depth - 1);
-            renderPath(g, patchSubdivided.southEast, scaleX, scaleY, depth - 1);
-            renderPath(g, patchSubdivided.southWest, scaleX, scaleY, depth - 1);
+            renderPath(output, patchSubdivided.northWest, scaleX, scaleY, depth - 1);
+            renderPath(output, patchSubdivided.northEast, scaleX, scaleY, depth - 1);
+            renderPath(output, patchSubdivided.southEast, scaleX, scaleY, depth - 1);
+            renderPath(output, patchSubdivided.southWest, scaleX, scaleY, depth - 1);
         }
     }
 

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/prototype/Renderable.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/prototype/Renderable.java
@@ -21,8 +21,6 @@
  */
 package com.github.weisj.jsvg.nodes.prototype;
 
-import java.awt.*;
-
 import org.jetbrains.annotations.NotNull;
 
 import com.github.weisj.jsvg.parser.AttributeNode;

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/prototype/Renderable.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/prototype/Renderable.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2021-2023 Jannis Weis
+ * Copyright (c) 2021-2024 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -26,6 +26,7 @@ import java.awt.*;
 import org.jetbrains.annotations.NotNull;
 
 import com.github.weisj.jsvg.parser.AttributeNode;
+import com.github.weisj.jsvg.renderer.Output;
 import com.github.weisj.jsvg.renderer.RenderContext;
 
 public interface Renderable {
@@ -42,7 +43,7 @@ public interface Renderable {
 
     boolean isVisible(@NotNull RenderContext context);
 
-    void render(@NotNull RenderContext context, @NotNull Graphics2D g);
+    void render(@NotNull RenderContext context, @NotNull Output output);
 
     default boolean parseIsVisible(@NotNull AttributeNode node) {
         return !"none".equals(node.getValue("display"))

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/prototype/Transformable.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/prototype/Transformable.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2021-2023 Jannis Weis
+ * Copyright (c) 2021-2024 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -29,6 +29,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import com.github.weisj.jsvg.geometry.size.MeasureContext;
+import com.github.weisj.jsvg.renderer.Output;
 import com.github.weisj.jsvg.renderer.RenderContext;
 
 public interface Transformable {
@@ -43,7 +44,7 @@ public interface Transformable {
     @NotNull
     Point2D transformOrigin(@NotNull MeasureContext context);
 
-    default void applyTransform(@Nullable Graphics2D g, @NotNull RenderContext context) {
+    default void applyTransform(@NotNull Output output, @NotNull RenderContext context) {
         AffineTransform transform = transform();
         if (transform != null) {
             Point2D transformOrigin = transformOrigin(context.measureContext());
@@ -53,7 +54,7 @@ public interface Transformable {
             conjugate.concatenate(transform);
             conjugate.translate(-transformOrigin.getX(), -transformOrigin.getY());
 
-            if (g != null) g.transform(conjugate);
+            output.applyTransform(conjugate);
             context.userSpaceTransform().concatenate(conjugate);
         }
     }

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/prototype/Transformable.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/prototype/Transformable.java
@@ -43,7 +43,7 @@ public interface Transformable {
     @NotNull
     Point2D transformOrigin(@NotNull MeasureContext context);
 
-    default void applyTransform(@NotNull Graphics2D g, @NotNull RenderContext context) {
+    default void applyTransform(@Nullable Graphics2D g, @NotNull RenderContext context) {
         AffineTransform transform = transform();
         if (transform != null) {
             Point2D transformOrigin = transformOrigin(context.measureContext());
@@ -53,7 +53,7 @@ public interface Transformable {
             conjugate.concatenate(transform);
             conjugate.translate(-transformOrigin.getX(), -transformOrigin.getY());
 
-            g.transform(conjugate);
+            if (g != null) g.transform(conjugate);
             context.userSpaceTransform().concatenate(conjugate);
         }
     }

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/text/GlyphRenderer.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/text/GlyphRenderer.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2021-2023 Jannis Weis
+ * Copyright (c) 2021-2024 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -35,6 +35,7 @@ import com.github.weisj.jsvg.attributes.font.SVGFont;
 import com.github.weisj.jsvg.geometry.size.Length;
 import com.github.weisj.jsvg.geometry.size.MeasureContext;
 import com.github.weisj.jsvg.renderer.FontRenderContext;
+import com.github.weisj.jsvg.renderer.Output;
 import com.github.weisj.jsvg.renderer.RenderContext;
 import com.github.weisj.jsvg.renderer.ShapeRenderer;
 
@@ -60,7 +61,7 @@ final class GlyphRenderer {
         segment.currentRenderContext = context;
     }
 
-    static void renderGlyphRun(@NotNull Graphics2D g, @NotNull PaintOrder paintOrder,
+    static void renderGlyphRun(@NotNull Output output, @NotNull PaintOrder paintOrder,
             @NotNull Set<VectorEffect> vectorEffects, @NotNull StringTextSegment segment,
             @NotNull Rectangle2D completeGlyphRunBounds) {
         RenderContext context = segment.currentRenderContext;
@@ -74,7 +75,7 @@ final class GlyphRenderer {
         Stroke stroke = context.stroke(1f);
 
         // Todo: Vector-Effects
-        ShapeRenderer.renderWithPaintOrder(g, true, paintOrder,
+        ShapeRenderer.renderWithPaintOrder(output, true, paintOrder,
                 new ShapeRenderer.ShapePaintContext(context, vectorEffects, stroke, null),
                 new ShapeRenderer.PaintShape(glyphRun, completeGlyphRunBounds),
                 null);

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/text/LinearTextContainer.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/text/LinearTextContainer.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2021 Jannis Weis
+ * Copyright (c) 2021-2024 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -30,6 +30,7 @@ import org.jetbrains.annotations.NotNull;
 
 import com.github.weisj.jsvg.geometry.size.Length;
 import com.github.weisj.jsvg.parser.AttributeNode;
+import com.github.weisj.jsvg.renderer.Output;
 import com.github.weisj.jsvg.renderer.RenderContext;
 
 abstract class LinearTextContainer extends TextContainer {
@@ -59,8 +60,8 @@ abstract class LinearTextContainer extends TextContainer {
     }
 
     @Override
-    public void render(@NotNull RenderContext context, @NotNull Graphics2D g) {
-        renderSegment(createCursor(), context, g);
+    public void render(@NotNull RenderContext context, @NotNull Output output) {
+        renderSegment(createCursor(), context, output);
     }
 
     private @NotNull GlyphCursor createCursor() {

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/text/TextContainer.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/text/TextContainer.java
@@ -21,7 +21,6 @@
  */
 package com.github.weisj.jsvg.nodes.text;
 
-import java.awt.*;
 import java.awt.geom.Path2D;
 import java.awt.geom.Rectangle2D;
 import java.util.ArrayList;

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/text/TextContainer.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/text/TextContainer.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2021-2023 Jannis Weis
+ * Copyright (c) 2021-2024 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -120,13 +120,13 @@ abstract class TextContainer extends BaseContainerNode<TextSegment>
     protected abstract void cleanUpLocalCursor(@NotNull GlyphCursor current, @NotNull GlyphCursor local);
 
     protected final void renderSegment(@NotNull GlyphCursor cursor, @NotNull RenderContext context,
-            @NotNull Graphics2D g) {
+            @NotNull Output output) {
         prepareSegmentForRendering(cursor, context);
 
         double offset = textAnchorOffset(context.fontRenderContext().textAnchor(), cursor);
-        context.translate(g, -offset, 0);
+        context.translate(output, -offset, 0);
 
-        renderSegmentWithoutLayout(cursor, context, g);
+        renderSegmentWithoutLayout(cursor, context, output);
     }
 
     private double textAnchorOffset(@NotNull TextAnchor textAnchor, @NotNull GlyphCursor glyphCursor) {
@@ -234,15 +234,15 @@ abstract class TextContainer extends BaseContainerNode<TextSegment>
 
     @Override
     public void renderSegmentWithoutLayout(@NotNull GlyphCursor cursor, @NotNull RenderContext context,
-            @NotNull Graphics2D g) {
+            @NotNull Output output) {
         forEachSegment(context,
                 (segment, ctx) -> {
                     if (isVisible(ctx)) {
-                        GlyphRenderer.renderGlyphRun(g, paintOrder, vectorEffects(), segment,
+                        GlyphRenderer.renderGlyphRun(output, paintOrder, vectorEffects(), segment,
                                 cursor.completeGlyphRunBounds);
                     }
                 },
-                (segment, ctx) -> segment.renderSegmentWithoutLayout(cursor, ctx, g));
+                (segment, ctx) -> segment.renderSegmentWithoutLayout(cursor, ctx, output));
     }
 
     @Override

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/text/TextPath.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/text/TextPath.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2021-2023 Jannis Weis
+ * Copyright (c) 2021-2024 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -46,6 +46,7 @@ import com.github.weisj.jsvg.nodes.prototype.spec.ElementCategories;
 import com.github.weisj.jsvg.nodes.prototype.spec.NotImplemented;
 import com.github.weisj.jsvg.nodes.prototype.spec.PermittedContent;
 import com.github.weisj.jsvg.parser.AttributeNode;
+import com.github.weisj.jsvg.renderer.Output;
 import com.github.weisj.jsvg.renderer.RenderContext;
 import com.github.weisj.jsvg.util.PathUtil;
 
@@ -109,12 +110,10 @@ public final class TextPath extends TextContainer {
     }
 
     @Override
-    public void render(@NotNull RenderContext context, @NotNull Graphics2D g) {
-        renderSegment(createCursor(context), context, g);
+    public void render(@NotNull RenderContext context, @NotNull Output output) {
+        renderSegment(createCursor(context), context, output);
         if (DEBUG) {
-            Graphics2D debugGraphics = (Graphics2D) g.create();
-            paintDebugPath(context, debugGraphics);
-            debugGraphics.dispose();
+            output.debugPaint(g -> paintDebugPath(context, g));
         }
     }
 

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/text/TextSegment.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/text/TextSegment.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2021-2022 Jannis Weis
+ * Copyright (c) 2021-2024 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -21,11 +21,11 @@
  */
 package com.github.weisj.jsvg.nodes.text;
 
-import java.awt.*;
 import java.awt.geom.Path2D;
 
 import org.jetbrains.annotations.NotNull;
 
+import com.github.weisj.jsvg.renderer.Output;
 import com.github.weisj.jsvg.renderer.RenderContext;
 
 interface TextSegment {
@@ -34,7 +34,7 @@ interface TextSegment {
         void prepareSegmentForRendering(@NotNull GlyphCursor cursor, @NotNull RenderContext context);
 
         void renderSegmentWithoutLayout(@NotNull GlyphCursor cursor, @NotNull RenderContext context,
-                @NotNull Graphics2D g);
+                @NotNull Output output);
 
         boolean hasFixedLength();
 

--- a/jsvg/src/main/java/com/github/weisj/jsvg/parser/css/impl/Lexer.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/parser/css/impl/Lexer.java
@@ -92,6 +92,7 @@ public final class Lexer {
                     next();
                     return new Token(TokenType.COMMENT, comment);
                 }
+                // fall through
             default:
                 return new Token(TokenType.IDENTIFIER, readIdentifier());
         }

--- a/jsvg/src/main/java/com/github/weisj/jsvg/parser/css/impl/Lexer.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/parser/css/impl/Lexer.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jannis Weis
+ * Copyright (c) 2023-2024 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -146,7 +146,7 @@ public final class Lexer {
         int start = startIndex;
         for (int i = startListIndex; i <= endListIndex; i++) {
             char[] segment = input.get(i);
-            int end = (i == endListIndex) ? endIndex : segment.length - 1;
+            int end = (i == endListIndex) ? endIndex : segment.length;
 
             builder.append(String.valueOf(segment, start, end - start));
             start = 0;

--- a/jsvg/src/main/java/com/github/weisj/jsvg/parser/resources/ImageResource.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/parser/resources/ImageResource.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jannis Weis
+ * Copyright (c) 2023-2024 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -29,7 +29,7 @@ import org.jetbrains.annotations.NotNull;
 
 import com.github.weisj.jsvg.SVGRenderingHints;
 import com.github.weisj.jsvg.geometry.size.FloatSize;
-import com.github.weisj.jsvg.renderer.GraphicsUtil;
+import com.github.weisj.jsvg.renderer.Output;
 import com.github.weisj.jsvg.renderer.RenderContext;
 
 public class ImageResource implements RenderableResource {
@@ -47,19 +47,19 @@ public class ImageResource implements RenderableResource {
     }
 
     @Override
-    public void render(@NotNull Graphics2D g, @NotNull RenderContext context, @NotNull AffineTransform imgTransform) {
+    public void render(@NotNull Output output, @NotNull RenderContext context, @NotNull AffineTransform imgTransform) {
         int imgWidth = image.getWidth();
         int imgHeight = image.getHeight();
 
-        Object imageAntialiasing = g.getRenderingHint(SVGRenderingHints.KEY_IMAGE_ANTIALIASING);
+        Object imageAntialiasing = output.renderingHint(SVGRenderingHints.KEY_IMAGE_ANTIALIASING);
         if (imageAntialiasing == SVGRenderingHints.VALUE_IMAGE_ANTIALIASING_OFF) {
-            g.drawImage(image, imgTransform, context.platformSupport().imageObserver());
+            output.drawImage(image, imgTransform, context.platformSupport().imageObserver());
         } else {
-            g.transform(imgTransform);
+            output.applyTransform(imgTransform);
             Rectangle imgRect = new Rectangle(0, 0, imgWidth, imgHeight);
             // Painting using a TexturePaint allows for anti-aliased edges with a nontrivial transform
-            GraphicsUtil.safelySetPaint(g, new TexturePaint(image, imgRect));
-            g.fill(imgRect);
+            output.setPaint(new TexturePaint(image, imgRect));
+            output.fillShape(imgRect);
         }
     }
 }

--- a/jsvg/src/main/java/com/github/weisj/jsvg/parser/resources/MissingImageResource.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/parser/resources/MissingImageResource.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jannis Weis
+ * Copyright (c) 2023-2024 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -32,6 +32,7 @@ import com.github.weisj.jsvg.SVGDocument;
 import com.github.weisj.jsvg.attributes.ViewBox;
 import com.github.weisj.jsvg.geometry.size.FloatSize;
 import com.github.weisj.jsvg.parser.SVGLoader;
+import com.github.weisj.jsvg.renderer.Output;
 import com.github.weisj.jsvg.renderer.RenderContext;
 import com.github.weisj.jsvg.util.LazyProvider;
 
@@ -71,10 +72,10 @@ public final class MissingImageResource implements RenderableResource {
     }
 
     @Override
-    public void render(@NotNull Graphics2D g, @NotNull RenderContext context, @NotNull AffineTransform transform) {
-        g.transform(transform);
+    public void render(@NotNull Output output, @NotNull RenderContext context, @NotNull AffineTransform transform) {
+        output.applyTransform(transform);
         synchronized (missingImage) {
-            missingImage.get().renderWithPlatform(context.platformSupport(), g, new ViewBox(0, 0, SIZE, SIZE));
+            missingImage.get().renderWithPlatform(context.platformSupport(), output, new ViewBox(0, 0, SIZE, SIZE));
         }
     }
 }

--- a/jsvg/src/main/java/com/github/weisj/jsvg/parser/resources/MissingImageResource.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/parser/resources/MissingImageResource.java
@@ -21,7 +21,6 @@
  */
 package com.github.weisj.jsvg.parser.resources;
 
-import java.awt.*;
 import java.awt.geom.AffineTransform;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;

--- a/jsvg/src/main/java/com/github/weisj/jsvg/parser/resources/RenderableResource.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/parser/resources/RenderableResource.java
@@ -21,7 +21,6 @@
  */
 package com.github.weisj.jsvg.parser.resources;
 
-import java.awt.*;
 import java.awt.geom.AffineTransform;
 
 import org.jetbrains.annotations.NotNull;

--- a/jsvg/src/main/java/com/github/weisj/jsvg/parser/resources/RenderableResource.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/parser/resources/RenderableResource.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jannis Weis
+ * Copyright (c) 2023-2024 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -27,6 +27,7 @@ import java.awt.geom.AffineTransform;
 import org.jetbrains.annotations.NotNull;
 
 import com.github.weisj.jsvg.geometry.size.FloatSize;
+import com.github.weisj.jsvg.renderer.Output;
 import com.github.weisj.jsvg.renderer.RenderContext;
 
 public interface RenderableResource {
@@ -34,5 +35,5 @@ public interface RenderableResource {
     @NotNull
     FloatSize intrinsicSize(@NotNull RenderContext context);
 
-    void render(@NotNull Graphics2D g, @NotNull RenderContext context, @NotNull AffineTransform transform);
+    void render(@NotNull Output output, @NotNull RenderContext context, @NotNull AffineTransform transform);
 }

--- a/jsvg/src/main/java/com/github/weisj/jsvg/parser/resources/SVGResource.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/parser/resources/SVGResource.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jannis Weis
+ * Copyright (c) 2023-2024 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -28,6 +28,7 @@ import org.jetbrains.annotations.NotNull;
 
 import com.github.weisj.jsvg.SVGDocument;
 import com.github.weisj.jsvg.geometry.size.FloatSize;
+import com.github.weisj.jsvg.renderer.Output;
 import com.github.weisj.jsvg.renderer.RenderContext;
 
 public class SVGResource implements RenderableResource {
@@ -43,8 +44,8 @@ public class SVGResource implements RenderableResource {
     }
 
     @Override
-    public void render(@NotNull Graphics2D g, @NotNull RenderContext context, @NotNull AffineTransform imgTransform) {
-        g.transform(imgTransform);
-        document.renderWithPlatform(context.platformSupport(), g, null);
+    public void render(@NotNull Output output, @NotNull RenderContext context, @NotNull AffineTransform imgTransform) {
+        output.applyTransform(imgTransform);
+        document.renderWithPlatform(context.platformSupport(), output, null);
     }
 }

--- a/jsvg/src/main/java/com/github/weisj/jsvg/parser/resources/SVGResource.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/parser/resources/SVGResource.java
@@ -21,7 +21,6 @@
  */
 package com.github.weisj.jsvg.parser.resources;
 
-import java.awt.*;
 import java.awt.geom.AffineTransform;
 
 import org.jetbrains.annotations.NotNull;

--- a/jsvg/src/main/java/com/github/weisj/jsvg/renderer/Graphics2DOutput.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/renderer/Graphics2DOutput.java
@@ -1,0 +1,182 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 Jannis Weis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package com.github.weisj.jsvg.renderer;
+
+import java.awt.*;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
+import java.awt.image.ImageObserver;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import com.github.weisj.jsvg.util.GraphicsResetHelper;
+
+public class Graphics2DOutput implements Output {
+    private final Graphics2D g;
+
+    public Graphics2DOutput(@NotNull Graphics2D g) {
+        this.g = g;
+    }
+
+    @Override
+    public void fillShape(@NotNull Shape shape) {
+        g.fill(shape);
+    }
+
+    @Override
+    public void drawShape(@NotNull Shape shape) {
+        g.draw(shape);
+    }
+
+    @Override
+    public void drawImage(@NotNull BufferedImage image) {
+        g.drawImage(image, 0, 0, image.getWidth(), image.getHeight(), null, null);
+    }
+
+    @Override
+    public void drawImage(@NotNull Image image, @Nullable ImageObserver observer) {
+        g.drawImage(image, 0, 0, null);
+    }
+
+    @Override
+    public void drawImage(@NotNull Image image, @NotNull AffineTransform at, @Nullable ImageObserver observer) {
+        g.drawImage(image, at, observer);
+    }
+
+    @Override
+    public void setPaint(@NotNull Paint paint) {
+        GraphicsUtil.safelySetPaint(g, paint);
+    }
+
+    @Override
+    public void setStroke(@NotNull Stroke stroke) {
+        g.setStroke(stroke);
+    }
+
+    @Override
+    public @NotNull Stroke stroke() {
+        return g.getStroke();
+    }
+
+    @Override
+    public void applyClip(@NotNull Shape clipShape) {
+        g.clip(clipShape);
+    }
+
+    @Override
+    public void setClip(@NotNull Shape shape) {
+        g.setClip(shape);
+    }
+
+    @Override
+    public @NotNull Shape clip() {
+        return g.getClip();
+    }
+
+    @Override
+    public Optional<Float> contextFontSize() {
+        Font f = g.getFont();
+        if (f != null) return Optional.of(f.getSize2D());
+        return Optional.empty();
+    }
+
+    @Override
+    public @NotNull Output createChild() {
+        return new Graphics2DOutput((Graphics2D) g.create());
+    }
+
+    @Override
+    public void dispose() {
+        g.dispose();
+    }
+
+    @Override
+    public void debugPaint(@NotNull Consumer<Graphics2D> painter) {
+        Graphics2D debugGraphics = (Graphics2D) g.create();
+        painter.accept(debugGraphics);
+        debugGraphics.dispose();
+    }
+
+    @Override
+    public @NotNull Rectangle2D clipBounds() {
+        return g.getClipBounds();
+    }
+
+    @Override
+    public @NotNull RenderingHints renderingHints() {
+        return g.getRenderingHints();
+    }
+
+    @Override
+    public @Nullable Object renderingHint(RenderingHints.@NotNull Key key) {
+        return g.getRenderingHint(key);
+    }
+
+    @Override
+    public void setRenderingHint(RenderingHints.@NotNull Key key, @Nullable Object value) {
+        g.setRenderingHint(key, value);
+    }
+
+    @Override
+    public @NotNull AffineTransform transform() {
+        return g.getTransform();
+    }
+
+    @Override
+    public void setTransform(@NotNull AffineTransform affineTransform) {
+        g.setTransform(affineTransform);
+    }
+
+    @Override
+    public void applyTransform(@NotNull AffineTransform transform) {
+        g.transform(transform);
+    }
+
+    @Override
+    public void rotate(double angle) {
+        g.rotate(angle);
+    }
+
+    @Override
+    public void scale(double sx, double sy) {
+        g.scale(sx, sy);
+    }
+
+    @Override
+    public void translate(double dx, double dy) {
+        g.translate(dx, dy);
+    }
+
+    @Override
+    public void applyOpacity(float opacity) {
+        g.setComposite(GraphicsUtil.deriveComposite(g, opacity));
+    }
+
+    @Override
+    public @NotNull SafeState safeState() {
+        return new GraphicsResetHelper(g);
+    }
+}

--- a/jsvg/src/main/java/com/github/weisj/jsvg/renderer/Graphics2DOutput.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/renderer/Graphics2DOutput.java
@@ -38,6 +38,10 @@ import com.github.weisj.jsvg.util.Provider;
 public class Graphics2DOutput implements Output {
     private final Graphics2D g;
 
+    public @NotNull Graphics2D graphics() {
+        return g;
+    }
+
     public Graphics2DOutput(@NotNull Graphics2D g) {
         this.g = g;
     }

--- a/jsvg/src/main/java/com/github/weisj/jsvg/renderer/Graphics2DOutput.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/renderer/Graphics2DOutput.java
@@ -185,4 +185,9 @@ public class Graphics2DOutput implements Output {
     public boolean supportsFilters() {
         return true;
     }
+
+    @Override
+    public boolean supportsColors() {
+        return true;
+    }
 }

--- a/jsvg/src/main/java/com/github/weisj/jsvg/renderer/Graphics2DOutput.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/renderer/Graphics2DOutput.java
@@ -33,6 +33,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import com.github.weisj.jsvg.util.GraphicsResetHelper;
+import com.github.weisj.jsvg.util.Provider;
 
 public class Graphics2DOutput implements Output {
     private final Graphics2D g;
@@ -72,6 +73,11 @@ public class Graphics2DOutput implements Output {
     }
 
     @Override
+    public void setPaint(@NotNull Provider<Paint> paintProvider) {
+        setPaint(paintProvider.get());
+    }
+
+    @Override
     public void setStroke(@NotNull Stroke stroke) {
         g.setStroke(stroke);
     }
@@ -87,7 +93,7 @@ public class Graphics2DOutput implements Output {
     }
 
     @Override
-    public void setClip(@NotNull Shape shape) {
+    public void setClip(@Nullable Shape shape) {
         g.setClip(shape);
     }
 
@@ -178,5 +184,10 @@ public class Graphics2DOutput implements Output {
     @Override
     public @NotNull SafeState safeState() {
         return new GraphicsResetHelper(g);
+    }
+
+    @Override
+    public boolean supportsFilters() {
+        return true;
     }
 }

--- a/jsvg/src/main/java/com/github/weisj/jsvg/renderer/Graphics2DOutput.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/renderer/Graphics2DOutput.java
@@ -98,11 +98,6 @@ public class Graphics2DOutput implements Output {
     }
 
     @Override
-    public @NotNull Shape clip() {
-        return g.getClip();
-    }
-
-    @Override
     public Optional<Float> contextFontSize() {
         Font f = g.getFont();
         if (f != null) return Optional.of(f.getSize2D());

--- a/jsvg/src/main/java/com/github/weisj/jsvg/renderer/NodeRenderer.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/renderer/NodeRenderer.java
@@ -131,9 +131,11 @@ public final class NodeRenderer {
             Mask mask = ((HasClip) renderable).mask();
             if (mask != null) {
                 // Todo: Proper object bounding box
-                elementBounds = elementBounds(renderable, childContext);
-                if (!elementBounds.isEmpty()) {
-                    childOutput.setPaint(mask.createMaskPaint(childOutput, childContext, elementBounds));
+
+                Rectangle2D bounds = elementBounds(renderable, childContext);
+                elementBounds = bounds;
+                if (!bounds.isEmpty()) {
+                    childOutput.setPaint(() -> mask.createMaskPaint(childOutput, childContext, bounds));
                 }
             }
 
@@ -171,7 +173,7 @@ public final class NodeRenderer {
                 ? ((HasFilter) renderable).filter()
                 : null;
 
-        if (filter != null && filter.hasEffect()) {
+        if (filter != null && filter.hasEffect() && childOutput.supportsFilters()) {
             if (elementBounds == null) elementBounds = elementBounds(renderable, childContext);
             return InfoWithFilter.create(renderable, childContext, childOutput, filter, elementBounds);
         }

--- a/jsvg/src/main/java/com/github/weisj/jsvg/renderer/NodeRenderer.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/renderer/NodeRenderer.java
@@ -149,14 +149,14 @@ public final class NodeRenderer {
                 Shape childClipShape = childClip.clipShape(childContext, elementBounds);
 
                 if (CLIP_DEBUG) {
-                    output.debugPaint(g -> {
+                    childOutput.debugPaint(g -> {
                         g.setClip(null);
                         g.setPaint(Color.MAGENTA);
                         g.draw(childClipShape);
                     });
                 }
 
-                output.applyClip(childClipShape);
+                childOutput.applyClip(childClipShape);
             }
         }
 

--- a/jsvg/src/main/java/com/github/weisj/jsvg/renderer/Output.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/renderer/Output.java
@@ -65,9 +65,6 @@ public interface Output {
 
     void setClip(@Nullable Shape shape);
 
-    @Nullable
-    Shape clip();
-
     Optional<Float> contextFontSize();
 
     @NotNull

--- a/jsvg/src/main/java/com/github/weisj/jsvg/renderer/Output.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/renderer/Output.java
@@ -32,6 +32,8 @@ import java.util.function.Consumer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import com.github.weisj.jsvg.util.Provider;
+
 public interface Output {
 
     void fillShape(@NotNull Shape shape);
@@ -45,6 +47,14 @@ public interface Output {
     void drawImage(@NotNull Image image, @NotNull AffineTransform at, @Nullable ImageObserver observer);
 
     void setPaint(@NotNull Paint paint);
+
+    /**
+     * Set the paint used for the output. Use this version if computing the paint is expensive.
+     * Outputs which don't support paints can avoid the computation.
+     *
+     * @param paintProvider The paint provider.
+     */
+    void setPaint(@NotNull Provider<Paint> paintProvider);
 
     void setStroke(@NotNull Stroke stroke);
 
@@ -95,6 +105,8 @@ public interface Output {
 
     @NotNull
     SafeState safeState();
+
+    boolean supportsFilters();
 
     interface SafeState {
         void restore();

--- a/jsvg/src/main/java/com/github/weisj/jsvg/renderer/Output.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/renderer/Output.java
@@ -1,0 +1,102 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 Jannis Weis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package com.github.weisj.jsvg.renderer;
+
+import java.awt.*;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
+import java.awt.image.ImageObserver;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public interface Output {
+
+    void fillShape(@NotNull Shape shape);
+
+    void drawShape(@NotNull Shape shape);
+
+    void drawImage(@NotNull BufferedImage image);
+
+    void drawImage(@NotNull Image image, @Nullable ImageObserver observer);
+
+    void drawImage(@NotNull Image image, @NotNull AffineTransform at, @Nullable ImageObserver observer);
+
+    void setPaint(@NotNull Paint paint);
+
+    void setStroke(@NotNull Stroke stroke);
+
+    @NotNull
+    Stroke stroke();
+
+    void applyClip(@NotNull Shape clipShape);
+
+    void setClip(@Nullable Shape shape);
+
+    @Nullable
+    Shape clip();
+
+    Optional<Float> contextFontSize();
+
+    @NotNull
+    Output createChild();
+
+    void dispose();
+
+    void debugPaint(@NotNull Consumer<Graphics2D> painter);
+
+    @NotNull
+    Rectangle2D clipBounds();
+
+    @Nullable
+    RenderingHints renderingHints();
+
+    @Nullable
+    Object renderingHint(@NotNull RenderingHints.Key key);
+
+    void setRenderingHint(@NotNull RenderingHints.Key key, @Nullable Object value);
+
+    @NotNull
+    AffineTransform transform();
+
+    void setTransform(@NotNull AffineTransform affineTransform);
+
+    void applyTransform(@NotNull AffineTransform transform);
+
+    void rotate(double angle);
+
+    void scale(double sx, double sy);
+
+    void translate(double dx, double dy);
+
+    void applyOpacity(float opacity);
+
+    @NotNull
+    SafeState safeState();
+
+    interface SafeState {
+        void restore();
+    }
+}

--- a/jsvg/src/main/java/com/github/weisj/jsvg/renderer/Output.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/renderer/Output.java
@@ -105,6 +105,8 @@ public interface Output {
 
     boolean supportsFilters();
 
+    boolean supportsColors();
+
     interface SafeState {
         void restore();
     }

--- a/jsvg/src/main/java/com/github/weisj/jsvg/renderer/RenderContext.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/renderer/RenderContext.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2021-2023 Jannis Weis
+ * Copyright (c) 2021-2024 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -151,28 +151,28 @@ public final class RenderContext {
         this.userSpaceTransform.setTransform(userSpaceTransform);
     }
 
-    public void translate(@NotNull Graphics2D g, @NotNull Point2D dp) {
-        translate(g, dp.getX(), dp.getY());
+    public void translate(@NotNull Output output, @NotNull Point2D dp) {
+        translate(output, dp.getX(), dp.getY());
     }
 
-    public void translate(@NotNull Graphics2D g, double dx, double dy) {
+    public void translate(@NotNull Output output, double dx, double dy) {
         // TODO: Do this for remaining calls to translate/transform/scale etc.
-        g.translate(dx, dy);
+        output.translate(dx, dy);
         userSpaceTransform.translate(dx, dy);
     }
 
-    public void scale(@NotNull Graphics2D g, double sx, double sy) {
-        g.scale(sx, sy);
+    public void scale(@NotNull Output output, double sx, double sy) {
+        output.scale(sx, sy);
         userSpaceTransform.scale(sx, sy);
     }
 
-    public void rotate(@NotNull Graphics2D g, double angle) {
-        g.rotate(angle);
+    public void rotate(@NotNull Output output, double angle) {
+        output.rotate(angle);
         userSpaceTransform.rotate(angle);
     }
 
-    public void transform(@NotNull Graphics2D g, @NotNull AffineTransform at) {
-        g.transform(at);
+    public void transform(@NotNull Output output, @NotNull AffineTransform at) {
+        output.applyTransform(at);
         userSpaceTransform.concatenate(at);
     }
 

--- a/jsvg/src/main/java/com/github/weisj/jsvg/renderer/ShapeOutput.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/renderer/ShapeOutput.java
@@ -1,0 +1,2 @@
+package com.github.weisj.jsvg.renderer;public class ShapeOutput {
+}

--- a/jsvg/src/main/java/com/github/weisj/jsvg/renderer/ShapeOutput.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/renderer/ShapeOutput.java
@@ -24,7 +24,6 @@ package com.github.weisj.jsvg.renderer;
 import java.awt.*;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Area;
-import java.awt.geom.Path2D;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
 import java.awt.image.ImageObserver;
@@ -39,13 +38,13 @@ import com.github.weisj.jsvg.util.Provider;
 
 public class ShapeOutput implements Output {
 
-    private final @NotNull Path2D accumulatorShape;
+    private final @NotNull Area accumulatorShape;
     private @NotNull AffineTransform currentTransform;
     private @NotNull Stroke currentStroke;
     private @Nullable Area currentClip;
 
-    public ShapeOutput(@NotNull Path2D shape) {
-        accumulatorShape = shape;
+    public ShapeOutput(@NotNull Area area) {
+        accumulatorShape = area;
         currentStroke = new BasicStroke();
         currentTransform = new AffineTransform();
         currentClip = null;
@@ -67,11 +66,11 @@ public class ShapeOutput implements Output {
     private void append(@NotNull Shape shape, @NotNull AffineTransform transform) {
         AffineTransform at = new AffineTransform(currentTransform);
         at.concatenate(transform);
-        accumulatorShape.append(transformShape(shape, at), false);
+        accumulatorShape.add(new Area(transformShape(shape, at)));
     }
 
     private void append(@NotNull Shape shape) {
-        accumulatorShape.append(transformShape(shape, currentTransform), false);
+        accumulatorShape.add(new Area(transformShape(shape, currentTransform)));
     }
 
     @Override

--- a/jsvg/src/main/java/com/github/weisj/jsvg/renderer/ShapeOutput.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/renderer/ShapeOutput.java
@@ -34,6 +34,8 @@ import java.util.function.Consumer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import com.github.weisj.jsvg.util.Provider;
+
 
 public class ShapeOutput implements Output {
 
@@ -99,7 +101,12 @@ public class ShapeOutput implements Output {
 
     @Override
     public void setPaint(@NotNull Paint paint) {
-        // DO NOTHING
+        // Not supported. Do nothing
+    }
+
+    @Override
+    public void setPaint(@NotNull Provider<Paint> paintProvider) {
+        // Not supported. Do nothing
     }
 
     @Override
@@ -211,6 +218,11 @@ public class ShapeOutput implements Output {
     @Override
     public @NotNull SafeState safeState() {
         return new ShapeOutputSafeState(this);
+    }
+
+    @Override
+    public boolean supportsFilters() {
+        return false;
     }
 
     private static class ShapeOutputSafeState implements SafeState {

--- a/jsvg/src/main/java/com/github/weisj/jsvg/renderer/ShapeOutput.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/renderer/ShapeOutput.java
@@ -1,2 +1,236 @@
-package com.github.weisj.jsvg.renderer;public class ShapeOutput {
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 Jannis Weis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package com.github.weisj.jsvg.renderer;
+
+import java.awt.*;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Area;
+import java.awt.geom.Path2D;
+import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
+import java.awt.image.ImageObserver;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+
+public class ShapeOutput implements Output {
+
+    private final @NotNull Path2D accumulatorShape;
+    private @NotNull AffineTransform currentTransform;
+    private @NotNull Stroke currentStroke;
+    private @Nullable Area currentClip;
+
+    public ShapeOutput(@NotNull Path2D shape) {
+        accumulatorShape = shape;
+        currentStroke = new BasicStroke();
+        currentTransform = new AffineTransform();
+        currentClip = null;
+    }
+
+    private ShapeOutput(@NotNull ShapeOutput parent) {
+        accumulatorShape = parent.accumulatorShape;
+        currentStroke = parent.currentStroke;
+        currentTransform = new AffineTransform(parent.currentTransform);
+        currentClip = parent.currentClip != null ? new Area(parent.currentClip) : null;
+    }
+
+    private @NotNull Shape transformShape(@NotNull Shape shape, @NotNull AffineTransform transform) {
+        if (transform.isIdentity())
+            return shape;
+        return transform.createTransformedShape(shape);
+    }
+
+    private void append(@NotNull Shape shape, @NotNull AffineTransform transform) {
+        AffineTransform at = new AffineTransform(currentTransform);
+        at.concatenate(transform);
+        accumulatorShape.append(transformShape(shape, at), false);
+    }
+
+    private void append(@NotNull Shape shape) {
+        accumulatorShape.append(transformShape(shape, currentTransform), false);
+    }
+
+    @Override
+    public void fillShape(@NotNull Shape shape) {
+        append(shape);
+    }
+
+    @Override
+    public void drawShape(@NotNull Shape shape) {
+        append(currentStroke.createStrokedShape(shape));
+    }
+
+    @Override
+    public void drawImage(@NotNull BufferedImage image) {
+        append(new Rectangle2D.Float(0, 0, image.getWidth(), image.getHeight()));
+    }
+
+    @Override
+    public void drawImage(@NotNull Image image, @Nullable ImageObserver observer) {
+        append(new Rectangle2D.Float(0, 0, image.getWidth(null), image.getHeight(null)));
+    }
+
+    @Override
+    public void drawImage(@NotNull Image image, @NotNull AffineTransform at, @Nullable ImageObserver observer) {
+        append(new Rectangle2D.Float(0, 0, image.getWidth(null), image.getHeight(null)), at);
+    }
+
+    @Override
+    public void setPaint(@NotNull Paint paint) {
+        // DO NOTHING
+    }
+
+    @Override
+    public void setStroke(@NotNull Stroke stroke) {
+        currentStroke = stroke;
+    }
+
+    @Override
+    public @NotNull Stroke stroke() {
+        return currentStroke;
+    }
+
+    @Override
+    public void applyClip(@NotNull Shape clipShape) {
+        if (currentClip == null) {
+            currentClip = new Area(clipShape);
+        } else {
+            currentClip.intersect(new Area(clipShape));
+        }
+    }
+
+    @Override
+    public void setClip(@Nullable Shape shape) {
+        currentClip = shape != null ? new Area(shape) : null;
+    }
+
+    @Override
+    public @Nullable Shape clip() {
+        return currentClip;
+    }
+
+    @Override
+    public Optional<Float> contextFontSize() {
+        return Optional.empty();
+    }
+
+    @Override
+    public @NotNull Output createChild() {
+        return new ShapeOutput(this);
+    }
+
+    @Override
+    public void dispose() {
+        // No action needed
+    }
+
+    @Override
+    public void debugPaint(@NotNull Consumer<Graphics2D> painter) {
+        // Not supported. Do nothing
+    }
+
+    @Override
+    public @NotNull Rectangle2D clipBounds() {
+        float veryLargeNumber = Float.MAX_VALUE / 4;
+        return currentClip != null ? currentClip.getBounds2D()
+                : new Rectangle2D.Float(-veryLargeNumber, -veryLargeNumber, 2 * veryLargeNumber, 2 * veryLargeNumber);
+    }
+
+    @Override
+    public @Nullable RenderingHints renderingHints() {
+        return null;
+    }
+
+    @Override
+    public @Nullable Object renderingHint(RenderingHints.@NotNull Key key) {
+        return null;
+    }
+
+    @Override
+    public void setRenderingHint(RenderingHints.@NotNull Key key, @Nullable Object value) {
+        // Not supported. Do nothing
+    }
+
+    @Override
+    public @NotNull AffineTransform transform() {
+        return new AffineTransform(currentTransform);
+    }
+
+    @Override
+    public void setTransform(@NotNull AffineTransform affineTransform) {
+        currentTransform = new AffineTransform(affineTransform);
+    }
+
+    @Override
+    public void applyTransform(@NotNull AffineTransform transform) {
+        currentTransform.concatenate(transform);
+    }
+
+    @Override
+    public void rotate(double angle) {
+        currentTransform.rotate(angle);
+    }
+
+    @Override
+    public void scale(double sx, double sy) {
+        currentTransform.scale(sx, sy);
+    }
+
+    @Override
+    public void translate(double dx, double dy) {
+        currentTransform.translate(dx, dy);
+    }
+
+    @Override
+    public void applyOpacity(float opacity) {
+        // Not supported. Do nothing
+    }
+
+    @Override
+    public @NotNull SafeState safeState() {
+        return new ShapeOutputSafeState(this);
+    }
+
+    private static class ShapeOutputSafeState implements SafeState {
+        private final @NotNull ShapeOutput shapeOutput;
+        private final @NotNull Stroke oldStroke;
+        private final @NotNull AffineTransform oldTransform;
+        private final @Nullable Area oldClip;
+
+        private ShapeOutputSafeState(@NotNull ShapeOutput shapeOutput) {
+            this.shapeOutput = shapeOutput;
+            this.oldStroke = shapeOutput.stroke();
+            this.oldTransform = shapeOutput.transform();
+            this.oldClip = shapeOutput.currentClip != null ? new Area(shapeOutput.currentClip) : null;
+        }
+
+        @Override
+        public void restore() {
+            shapeOutput.currentStroke = oldStroke;
+            shapeOutput.currentTransform = oldTransform;
+            shapeOutput.currentClip = oldClip;
+        }
+    }
 }

--- a/jsvg/src/main/java/com/github/weisj/jsvg/renderer/ShapeOutput.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/renderer/ShapeOutput.java
@@ -81,6 +81,7 @@ public class ShapeOutput implements Output {
         append(shape);
     }
 
+
     @Override
     public void drawShape(@NotNull Shape shape) {
         append(currentStroke.createStrokedShape(shape));
@@ -225,6 +226,10 @@ public class ShapeOutput implements Output {
         return false;
     }
 
+    @Override
+    public boolean supportsColors() {
+        return false;
+    }
 
     private static class ShapeOutputSafeState implements SafeState {
         private final @NotNull ShapeOutput shapeOutput;

--- a/jsvg/src/main/java/com/github/weisj/jsvg/renderer/ShapeRenderer.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/renderer/ShapeRenderer.java
@@ -274,7 +274,7 @@ public final class ShapeRenderer {
         Output markerOutput = output.createChild();
         RenderContext markerContext = context.deriveForChildGraphics();
 
-        markerContext.translate(output, x, y);
+        markerContext.translate(markerOutput, x, y);
 
         if (DEBUG_MARKERS) {
             markerOutput.debugPaint(g -> paintDebugMarker(markerContext, g, marker, rotation));

--- a/jsvg/src/main/java/com/github/weisj/jsvg/util/GraphicsResetHelper.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/util/GraphicsResetHelper.java
@@ -57,6 +57,7 @@ public class GraphicsResetHelper implements Output.SafeState {
         return graphics;
     }
 
+    @Override
     public void restore() {
         graphics.setComposite(originalComposite);
         graphics.setPaint(originalPaint);

--- a/jsvg/src/main/java/com/github/weisj/jsvg/util/GraphicsResetHelper.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/util/GraphicsResetHelper.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jannis Weis
+ * Copyright (c) 2023-2024 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -24,14 +24,18 @@ package com.github.weisj.jsvg.util;
 import java.awt.*;
 import java.awt.geom.AffineTransform;
 
+import org.jetbrains.annotations.NotNull;
+
+import com.github.weisj.jsvg.renderer.Output;
+
 /**
  * A utility class that holds a {@link Graphics2D} object and is able to reset it back to its original configuration,
  * as this is often more efficient than creating a new graphics instance.
- *
+ * <
  * This class does not track what parameters have been modified, nor does it reset all configuration parameters. Which
  * parameters are reset should be expanded as needed.
  */
-public class GraphicsResetHelper {
+public class GraphicsResetHelper implements Output.SafeState {
 
     private final Graphics2D graphics;
 
@@ -40,7 +44,7 @@ public class GraphicsResetHelper {
     private final Stroke originalStroke;
     private final AffineTransform originalTransform;
 
-    public GraphicsResetHelper(Graphics2D graphics) {
+    public GraphicsResetHelper(@NotNull Graphics2D graphics) {
         this.graphics = graphics;
 
         originalComposite = graphics.getComposite();
@@ -49,11 +53,11 @@ public class GraphicsResetHelper {
         originalTransform = graphics.getTransform();
     }
 
-    public Graphics2D graphics() {
+    public @NotNull Graphics2D graphics() {
         return graphics;
     }
 
-    public void reset() {
+    public void restore() {
         graphics.setComposite(originalComposite);
         graphics.setPaint(originalPaint);
         graphics.setStroke(originalStroke);

--- a/jsvg/src/main/java/com/github/weisj/jsvg/util/ImageUtil.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/util/ImageUtil.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2021-2023 Jannis Weis
+ * Copyright (c) 2021-2024 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -30,14 +30,15 @@ import org.jetbrains.annotations.Nullable;
 
 import com.github.weisj.jsvg.geometry.util.GeometryUtil;
 import com.github.weisj.jsvg.renderer.GraphicsUtil;
+import com.github.weisj.jsvg.renderer.Output;
 import com.github.weisj.jsvg.renderer.RenderContext;
 
 public final class ImageUtil {
     private ImageUtil() {}
 
-    public static @NotNull BufferedImage createCompatibleTransparentImage(@NotNull Graphics2D g, double width,
-            double height) {
-        return createCompatibleTransparentImage(g.getTransform(), width, height);
+    public static @NotNull BufferedImage createCompatibleTransparentImage(@NotNull Output output,
+            double width, double height) {
+        return createCompatibleTransparentImage(output.transform(), width, height);
     }
 
     public static @NotNull BufferedImage createCompatibleTransparentImage(int width, int height) {

--- a/jsvg/src/main/java/com/github/weisj/jsvg/util/ShapeUtil.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/util/ShapeUtil.java
@@ -191,18 +191,6 @@ public final class ShapeUtil {
         return mat.createTransformedShape(s);
     }
 
-    public Shape untransformShape(@NotNull Shape s, @NotNull AffineTransform transform) {
-        if (transform.getType() > AffineTransform.TYPE_TRANSLATION) {
-            try {
-                return transformShape(transform.createInverse(), s);
-            } catch (NoninvertibleTransformException e) {
-                return null;
-            }
-        } else {
-            return transformShape(-transform.getTranslateX(), -transform.getTranslateY(), s);
-        }
-    }
-
     private static Shape cloneShape(Shape s) {
         return new GeneralPath(s);
     }

--- a/jsvg/src/main/java/com/github/weisj/jsvg/util/ShapeUtil.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/util/ShapeUtil.java
@@ -98,7 +98,8 @@ public final class ShapeUtil {
      */
     @NotNull
     private static Shape intersectByArea(@NotNull Shape s1, @NotNull Shape s2, boolean keep1, boolean keep2) {
-        Area a1, a2;
+        Area a1;
+        Area a2;
 
         // First see if we can find an overwrite-able source shape
         // to use as our destination area to avoid duplication.

--- a/jsvg/src/main/java/com/github/weisj/jsvg/util/ShapeUtil.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/util/ShapeUtil.java
@@ -1,0 +1,209 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 Jannis Weis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package com.github.weisj.jsvg.util;
+
+import java.awt.*;
+import java.awt.geom.*;
+
+import org.jetbrains.annotations.NotNull;
+
+public final class ShapeUtil {
+
+    private static final int NON_RECTILINEAR_TRANSFORM_MASK =
+            AffineTransform.TYPE_GENERAL_TRANSFORM | AffineTransform.TYPE_GENERAL_ROTATION;
+
+    private ShapeUtil() {}
+
+    /*
+     * Intersect two Shapes by the simplest method, attempting to produce a simplified result. The
+     * boolean arguments keep1 and keep2 specify whether or not the first or second shapes can be
+     * modified during the operation or whether that shape must be "kept" unmodified.
+     */
+    @NotNull
+    public static Shape intersect(@NotNull Shape s1, @NotNull Shape s2, boolean keep1, boolean keep2) {
+        if (s1 instanceof Rectangle && s2 instanceof Rectangle) {
+            return ((Rectangle) s1).intersection((Rectangle) s2);
+        }
+        if (s1 instanceof Rectangle2D) {
+            return intersectRectShape((Rectangle2D) s1, s2, keep1, keep2);
+        } else if (s2 instanceof Rectangle2D) {
+            return intersectRectShape((Rectangle2D) s2, s1, keep2, keep1);
+        }
+        return intersectByArea(s1, s2, keep1, keep2);
+    }
+
+    /*
+     * Intersect a Rectangle with a Shape by the simplest method, attempting to produce a simplified
+     * result. The boolean arguments keep1 and keep2 specify whether or not the first or second shapes
+     * can be modified during the operation or whether that shape must be "kept" unmodified.
+     */
+    @NotNull
+    private static Shape intersectRectShape(@NotNull Rectangle2D r, @NotNull Shape s,
+            boolean keep1, boolean keep2) {
+        if (s instanceof Rectangle2D) {
+            Rectangle2D r2 = (Rectangle2D) s;
+            Rectangle2D outputRect;
+            if (!keep1) {
+                outputRect = r;
+            } else if (!keep2) {
+                outputRect = r2;
+            } else {
+                outputRect = new Rectangle2D.Float();
+            }
+            double x1 = Math.max(r.getX(), r2.getX());
+            double x2 = Math.min(r.getX() + r.getWidth(), r2.getX() + r2.getWidth());
+            double y1 = Math.max(r.getY(), r2.getY());
+            double y2 = Math.min(r.getY() + r.getHeight(), r2.getY() + r2.getHeight());
+
+            if (((x2 - x1) < 0) || ((y2 - y1) < 0))
+                // Width or height is negative. No intersection.
+                outputRect.setFrameFromDiagonal(0, 0, 0, 0);
+            else
+                outputRect.setFrameFromDiagonal(x1, y1, x2, y2);
+            return outputRect;
+        }
+        if (r.contains(s.getBounds2D())) {
+            if (keep2) {
+                s = cloneShape(s);
+            }
+            return s;
+        }
+        return intersectByArea(r, s, keep1, keep2);
+    }
+
+    /*
+     * Intersect two Shapes using the Area class. Presumably other attempts at simpler intersection
+     * methods proved fruitless. The boolean arguments keep1 and keep2 specify whether or not the first
+     * or second shapes can be modified during the operation or whether that shape must be "kept"
+     * unmodified.
+     *
+     * @see #intersectShapes
+     *
+     * @see #intersectRectShape
+     */
+    @NotNull
+    private static Shape intersectByArea(@NotNull Shape s1, @NotNull Shape s2, boolean keep1, boolean keep2) {
+        Area a1, a2;
+
+        // First see if we can find an overwrite-able source shape
+        // to use as our destination area to avoid duplication.
+        if (!keep1 && (s1 instanceof Area)) {
+            a1 = (Area) s1;
+        } else if (!keep2 && (s2 instanceof Area)) {
+            a1 = (Area) s2;
+            s2 = s1;
+        } else {
+            a1 = new Area(s1);
+        }
+
+        if (s2 instanceof Area) {
+            a2 = (Area) s2;
+        } else {
+            a2 = new Area(s2);
+        }
+
+        a1.intersect(a2);
+        if (a1.isRectangular()) {
+            return a1.getBounds();
+        }
+
+        return a1;
+    }
+
+    public static @NotNull Shape transformShape(@NotNull Shape s, @NotNull AffineTransform transform) {
+        if (transform.getType() > AffineTransform.TYPE_TRANSLATION) {
+            return transformShape(transform, s);
+        } else {
+            return transformShape(transform.getTranslateX(), transform.getTranslateY(), s);
+        }
+    }
+
+    private static Shape transformShape(@NotNull AffineTransform tx, @NotNull Shape shape) {
+        if (shape instanceof Rectangle2D &&
+                (tx.getType() & NON_RECTILINEAR_TRANSFORM_MASK) == 0) {
+            Rectangle2D rect = (Rectangle2D) shape;
+            double[] matrix = new double[4];
+            matrix[0] = rect.getX();
+            matrix[1] = rect.getY();
+            matrix[2] = matrix[0] + rect.getWidth();
+            matrix[3] = matrix[1] + rect.getHeight();
+            tx.transform(matrix, 0, matrix, 0, 2);
+            fixRectangleOrientation(matrix, rect);
+            return new Rectangle2D.Double(matrix[0], matrix[1],
+                    matrix[2] - matrix[0],
+                    matrix[3] - matrix[1]);
+        }
+
+        if (tx.isIdentity()) {
+            return cloneShape(shape);
+        }
+
+        return tx.createTransformedShape(shape);
+    }
+
+    private static void fixRectangleOrientation(double[] m, @NotNull Rectangle2D r) {
+        if (r.getWidth() > 0 != (m[2] - m[0] > 0)) {
+            double t = m[0];
+            m[0] = m[2];
+            m[2] = t;
+        }
+        if (r.getHeight() > 0 != (m[3] - m[1] > 0)) {
+            double t = m[1];
+            m[1] = m[3];
+            m[3] = t;
+        }
+    }
+
+    private static @NotNull Shape transformShape(double tx, double ty, @NotNull Shape s) {
+        if (s instanceof Rectangle2D) {
+            Rectangle2D rect = (Rectangle2D) s;
+            return new Rectangle2D.Double(
+                    rect.getX() + tx,
+                    rect.getY() + ty,
+                    rect.getWidth(),
+                    rect.getHeight());
+        }
+
+        if (tx == 0 && ty == 0) {
+            return ShapeUtil.cloneShape(s);
+        }
+
+        AffineTransform mat = AffineTransform.getTranslateInstance(tx, ty);
+        return mat.createTransformedShape(s);
+    }
+
+    public Shape untransformShape(@NotNull Shape s, @NotNull AffineTransform transform) {
+        if (transform.getType() > AffineTransform.TYPE_TRANSLATION) {
+            try {
+                return transformShape(transform.createInverse(), s);
+            } catch (NoninvertibleTransformException e) {
+                return null;
+            }
+        } else {
+            return transformShape(-transform.getTranslateX(), -transform.getTranslateY(), s);
+        }
+    }
+
+    private static Shape cloneShape(Shape s) {
+        return new GeneralPath(s);
+    }
+}

--- a/jsvg/src/main/java/com/github/weisj/jsvg/util/ShapeUtil.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/util/ShapeUtil.java
@@ -95,10 +95,6 @@ public final class ShapeUtil {
      * methods proved fruitless. The boolean arguments keep1 and keep2 specify whether or not the first
      * or second shapes can be modified during the operation or whether that shape must be "kept"
      * unmodified.
-     *
-     * @see #intersectShapes
-     *
-     * @see #intersectRectShape
      */
     @NotNull
     private static Shape intersectByArea(@NotNull Shape s1, @NotNull Shape s2, boolean keep1, boolean keep2) {

--- a/jsvg/src/test/java/com/github/weisj/jsvg/CSSTest.java
+++ b/jsvg/src/test/java/com/github/weisj/jsvg/CSSTest.java
@@ -1,0 +1,36 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 Jannis Weis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package com.github.weisj.jsvg;
+
+import static com.github.weisj.jsvg.ReferenceTest.ReferenceTestResult.SUCCESS;
+import static com.github.weisj.jsvg.ReferenceTest.compareImages;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class CSSTest {
+
+    @Test
+    void testBrokenUpContent() {
+        assertEquals(SUCCESS, compareImages("css/brokenUpCharContent.svg"));
+    }
+}

--- a/jsvg/src/test/java/com/github/weisj/jsvg/ReferenceTest.java
+++ b/jsvg/src/test/java/com/github/weisj/jsvg/ReferenceTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2021-2023 Jannis Weis
+ * Copyright (c) 2021-2024 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -107,7 +107,7 @@ public final class ReferenceTest {
         }
     }
 
-    private static @NotNull ReferenceTest.ReferenceTestResult compareImageRasterization(@NotNull BufferedImage expected,
+    public static @NotNull ReferenceTest.ReferenceTestResult compareImageRasterization(@NotNull BufferedImage expected,
             @NotNull BufferedImage actual,
             @NotNull String name, double tolerance) {
         ImageComparison comp = new ImageComparison(expected, actual);

--- a/jsvg/src/test/java/com/github/weisj/jsvg/SVGViewer.java
+++ b/jsvg/src/test/java/com/github/weisj/jsvg/SVGViewer.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2021-2023 Jannis Weis
+ * Copyright (c) 2021-2024 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -80,11 +80,17 @@ public final class SVGViewer {
             renderingMode.add(jsvg);
             renderingMode.add(svgSalamander);
             renderingMode.add(batik);
+            renderingMode.add(Box.createHorizontalStrut(5));
+
+            JCheckBox paintShape = new JCheckBox("Paint SVG shape");
+            paintShape.addActionListener(e -> svgPanel.setPaintSVGShape(paintShape.isSelected()));
+            renderingMode.add(paintShape);
             renderingMode.add(Box.createHorizontalGlue());
 
             JButton resourceInfo = new JButton("Print Memory");
             resourceInfo.addActionListener(e -> svgPanel.printMemory());
             renderingMode.add(resourceInfo);
+
 
             frame.add(renderingMode, BorderLayout.SOUTH);
 
@@ -128,6 +134,7 @@ public final class SVGViewer {
             }
         };
         private final JSVGCanvas jsvgCanvas = new JSVGCanvas();
+        private boolean paintShape;
 
         public SVGPanel(@NotNull String iconName) {
             selectIcon(iconName);
@@ -188,6 +195,11 @@ public final class SVGViewer {
             selectIcon(selectedIconName);
         }
 
+        public void setPaintSVGShape(boolean paintShape) {
+            this.paintShape = paintShape;
+            repaint();
+        }
+
         @Override
         protected void paintComponent(Graphics g) {
             super.paintComponent(g);
@@ -198,7 +210,14 @@ public final class SVGViewer {
             System.out.println("======");
             switch (mode) {
                 case JSVG:
-                    document.render(this, (Graphics2D) g, new ViewBox(0, 0, getWidth(), getHeight()));
+                    ViewBox viewBox = new ViewBox(0, 0, getWidth(), getHeight());
+                    if (paintShape) {
+                        Shape shape = document.computeShape(viewBox);
+                        g.setColor(Color.MAGENTA);
+                        ((Graphics2D) g).fill(shape);
+                    } else {
+                        document.render(this, (Graphics2D) g, viewBox);
+                    }
                     break;
                 case SVG_SALAMANDER:
                     icon.paintIcon(this, g, 0, 0);

--- a/jsvg/src/test/java/com/github/weisj/jsvg/ToShapeTest.java
+++ b/jsvg/src/test/java/com/github/weisj/jsvg/ToShapeTest.java
@@ -1,0 +1,227 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 Jannis Weis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package com.github.weisj.jsvg;
+
+import static com.github.weisj.jsvg.ReferenceTest.ReferenceTestResult.SUCCESS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Objects;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.github.weisj.jsvg.attributes.ViewBox;
+import com.github.weisj.jsvg.geometry.size.FloatSize;
+import com.github.weisj.jsvg.parser.SVGLoader;
+import com.github.weisj.jsvg.renderer.Graphics2DOutput;
+import com.github.weisj.jsvg.renderer.Output;
+import com.github.weisj.jsvg.renderer.awt.NullPlatformSupport;
+import com.github.weisj.jsvg.util.Provider;
+
+class ToShapeTest {
+
+    @Test
+    void testStroke() {
+        assertEquals(SUCCESS, compareShape("stroke/stroke1.svg"));
+        assertEquals(SUCCESS, compareShape("stroke/stroke2.svg"));
+        assertEquals(SUCCESS, compareShape("stroke/stroke3.svg"));
+    }
+
+    @Test
+    void testGradient() {
+        assertEquals(SUCCESS, compareShape("gradient/linearGradient.svg"));
+        assertEquals(SUCCESS, compareShape("gradient/radialGradient.svg"));
+    }
+
+    @Test
+    void testAspectRatio() {
+        assertEquals(SUCCESS, compareShape("aspect/aspect.svg"));
+    }
+
+    @Test
+    void testMarker() {
+        assertEquals(SUCCESS, compareShape("marker/marker1.svg"));
+        assertEquals(SUCCESS, compareShape("marker/marker2.svg"));
+    }
+
+    @Test
+    void testMeshGradient() {
+        assertEquals(SUCCESS, compareShape("mesh/mesh.svg", 0.6f));
+    }
+
+    @Test
+    void testPath() {
+        assertEquals(SUCCESS, compareShape("path/closePath.svg"));
+        assertEquals(SUCCESS, compareShape("path/cubicBezier.svg"));
+        assertEquals(SUCCESS, compareShape("path/ellipticalArc.svg"));
+        assertEquals(SUCCESS, compareShape("path/lineTo.svg"));
+        assertEquals(SUCCESS, compareShape("path/moveTo.svg"));
+        assertEquals(SUCCESS, compareShape("path/quadraticBezier.svg"));
+    }
+
+    @Test
+    void testSymbol() {
+        assertEquals(SUCCESS, compareShape("symbol/symbol1.svg"));
+        assertEquals(SUCCESS, compareShape("symbol/symbol2.svg"));
+    }
+
+    @Test
+    void testText() {
+        assertEquals(SUCCESS, compareShape("text/text0.svg", 1f));
+        assertEquals(SUCCESS, compareShape("text/text1.svg", 1f));
+        assertEquals(SUCCESS, compareShape("text/textAnchor.svg", 1f));
+        assertEquals(SUCCESS, compareShape("text/textLength.svg", 1f));
+    }
+
+    @Test
+    void testTransform() {
+        assertEquals(SUCCESS, compareShape("transform/matrix.svg"));
+        assertEquals(SUCCESS, compareShape("transform/rotate.svg"));
+        assertEquals(SUCCESS, compareShape("transform/scale.svg"));
+        assertEquals(SUCCESS, compareShape("transform/skewX.svg"));
+        assertEquals(SUCCESS, compareShape("transform/skewY.svg"));
+        assertEquals(SUCCESS, compareShape("transform/SVGinSVG.svg"));
+        assertEquals(SUCCESS, compareShape("transform/transform.svg"));
+        assertEquals(SUCCESS, compareShape("transform/translate.svg"));
+    }
+
+    @Test
+    void testUnits() {
+        assertEquals(SUCCESS, compareShape("units/relativeUnits.svg"));
+        assertEquals(SUCCESS, compareShape("units/relativeUnits2.svg"));
+        assertEquals(SUCCESS, compareShape("units/relativeUnits3.svg"));
+    }
+
+    @Test
+    void testVectorEffect() {
+        assertEquals(SUCCESS, compareShape("vectorEffect/before.svg", 0.7f));
+        assertEquals(SUCCESS, compareShape("vectorEffect/fixedPosition.svg", 0.7f));
+        assertEquals(SUCCESS, compareShape("vectorEffect/none.svg", 0.7f));
+        assertEquals(SUCCESS, compareShape("vectorEffect/nonRotation.svg", 0.7f));
+        assertEquals(SUCCESS, compareShape("vectorEffect/nonRotationFixedPosition.svg", 0.7f));
+        assertEquals(SUCCESS, compareShape("vectorEffect/nonScalingSize.svg", 0.7f));
+        assertEquals(SUCCESS, compareShape("vectorEffect/nonScalingSizeFixedPosition.svg", 0.7f));
+        assertEquals(SUCCESS, compareShape("vectorEffect/nonScalingSizeNonRotation.svg", 0.7f));
+        assertEquals(SUCCESS, compareShape("vectorEffect/nonScalingSizeNonRotationFixedPosition.svg", 0.7f));
+        assertEquals(SUCCESS, compareShape("vectorEffect/nonScalingStroke.svg", 0.7f));
+    }
+
+    @Test
+    void testViewBox() {
+        assertEquals(SUCCESS, compareShape("viewBox/viewBox.svg"));
+        assertEquals(SUCCESS, compareShape("viewBox/viewBox2.svg"));
+        assertEquals(SUCCESS, compareShape("viewBox/viewBox3.svg"));
+    }
+
+    @Test
+    void testOther() {
+        assertEquals(SUCCESS, compareShape("clipPathUnits.svg"));
+        assertEquals(SUCCESS, compareShape("fillRule.svg"));
+        assertEquals(SUCCESS, compareShape("paintOrder.svg"));
+    }
+
+    private static @NotNull BufferedImage prepareImage(@NotNull SVGDocument document) {
+        FloatSize size = document.size();
+        int w = 2000;
+        int h = Math.round(w * (size.height / size.width));
+        BufferedImage image = new BufferedImage(w, h, BufferedImage.TYPE_BYTE_BINARY);
+        Graphics2D g = image.createGraphics();
+        g.setColor(Color.WHITE);
+        g.fillRect(0, 0, w, h);
+        g.dispose();
+        return image;
+    }
+
+    private static @NotNull BufferedImage renderReference(@NotNull SVGDocument document) {
+        BufferedImage img = prepareImage(document);
+        Graphics2D g = img.createGraphics();
+        g.setColor(Color.BLACK);
+        document.renderWithPlatform(
+                new NullPlatformSupport(),
+                new BlackAndWhiteOutput(g),
+                new ViewBox(0, 0, img.getWidth(), img.getHeight()));
+        g.dispose();
+        return img;
+    }
+
+    private static @NotNull BufferedImage renderShape(@NotNull SVGDocument document) {
+        BufferedImage img = prepareImage(document);
+        Shape shape = document.computeShape(new ViewBox(0, 0, img.getWidth(), img.getHeight()));
+        Graphics2D g = img.createGraphics();
+        g.setColor(Color.BLACK);
+        g.fill(shape);
+        g.dispose();
+        return img;
+    }
+
+    private static ReferenceTest.ReferenceTestResult compareShape(@NotNull String path) {
+        return compareShape(path, 0.5f);
+    }
+
+    private static ReferenceTest.ReferenceTestResult compareShape(@NotNull String path, float tolerance) {
+        try {
+            URL url = Objects.requireNonNull(ReferenceTest.class.getResource(path), path);
+            SVGDocument document = Objects.requireNonNull(new SVGLoader().load(url.openStream()));
+            BufferedImage expected = renderReference(document);
+            BufferedImage actual = renderShape(document);
+            return ReferenceTest.compareImageRasterization(expected, actual, path, tolerance);
+        } catch (IOException e) {
+            Assertions.fail(e);
+            return ReferenceTest.ReferenceTestResult.FAILURE;
+        }
+    }
+
+    private static class BlackAndWhiteOutput extends Graphics2DOutput {
+
+        public BlackAndWhiteOutput(@NotNull Graphics2D g) {
+            super(g);
+        }
+
+        @Override
+        public void setPaint(@NotNull Paint paint) {
+            // Only black and white allowed
+        }
+
+        @Override
+        public void setPaint(@NotNull Provider<Paint> paintProvider) {
+            // Only black and white allowed
+        }
+
+        @Override
+        public void applyOpacity(float opacity) {
+            if (opacity != 0) {
+                opacity = 1;
+            }
+            super.applyOpacity(opacity);
+        }
+
+        @Override
+        public @NotNull Output createChild() {
+            return new BlackAndWhiteOutput((Graphics2D) graphics().create());
+        }
+    }
+}

--- a/jsvg/src/test/java/com/github/weisj/jsvg/parser/UIFutureTest.java
+++ b/jsvg/src/test/java/com/github/weisj/jsvg/parser/UIFutureTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2023 Jannis Weis
+ * Copyright (c) 2022-2024 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -25,8 +25,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.awt.image.ImageObserver;
 import java.util.concurrent.CountDownLatch;
-
-import javax.swing.*;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;

--- a/jsvg/src/test/java/com/github/weisj/jsvg/parser/UIFutureTest.java
+++ b/jsvg/src/test/java/com/github/weisj/jsvg/parser/UIFutureTest.java
@@ -30,6 +30,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
+import com.github.weisj.jsvg.renderer.awt.NullPlatformSupport;
 import com.github.weisj.jsvg.renderer.awt.PlatformSupport;
 
 class UIFutureTest {
@@ -38,7 +39,7 @@ class UIFutureTest {
     void testValueUiFuture() {
         Object o = new Object();
         UIFuture<Object> future = new ValueUIFuture<>(o);
-        assertTrue(future.checkIfReady(null));
+        assertTrue(future.checkIfReady(new NullPlatformSupport()));
         assertEquals(o, future.get());
     }
 

--- a/jsvg/src/test/resources/com/github/weisj/jsvg/css/brokenUpCharContent.svg
+++ b/jsvg/src/test/resources/com/github/weisj/jsvg/css/brokenUpCharContent.svg
@@ -1,23 +1,45 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500"
 	viewBox="0 0 100 100">
 
 	<rect x="2.5%" y="25%" width="95%" height="50%"
 		class="longClassName" />
 
 	<style>
-		.l<desc>Stuff</desc>ongClassName
+		.l
+		<desc>Stuff</desc>
+		ongClassName
 		<desc>Stuff</desc>
 		{
 		<desc>Stuff</desc>
-		fi<desc>Stuff</desc>ll
+		fi
 		<desc>Stuff</desc>
-		: bl<desc>Stuff</desc>ue
+		ll
+		<desc>Stuff</desc>
+		: bl
+		<desc>Stuff</desc>
+		ue
 		<desc>Stuff</desc>
 		;
-		s<desc>Stuff</desc>t<desc>Stuff</desc>r<desc>Stuff</desc>o<desc>Stuff</desc>ke:
-        gre<desc>Stuff</desc>en;
+		s
 		<desc>Stuff</desc>
-		stro<desc>Stuff</desc>ke-<desc>Stuff</desc>widt<desc>Stuff</desc>h
+		t
+		<desc>Stuff</desc>
+		r
+		<desc>Stuff</desc>
+		o
+		<desc>Stuff</desc>
+		ke:
+		gre
+		<desc>Stuff</desc>
+		en;
+		<desc>Stuff</desc>
+		stro
+		<desc>Stuff</desc>
+		ke-
+		<desc>Stuff</desc>
+		widt
+		<desc>Stuff</desc>
+		h
 		<desc>Stuff</desc>
 		: 5%;
 		<desc>Stuff</desc>

--- a/jsvg/src/test/resources/com/github/weisj/jsvg/css/brokenUpCharContent.svg
+++ b/jsvg/src/test/resources/com/github/weisj/jsvg/css/brokenUpCharContent.svg
@@ -5,41 +5,19 @@
 		class="longClassName" />
 
 	<style>
-		.l
-		<desc>Stuff</desc>
-		ongClassName
+		.l<desc>Stuff</desc>ongClassName
 		<desc>Stuff</desc>
 		{
 		<desc>Stuff</desc>
-		fi
+		fi<desc>Stuff</desc>ll
 		<desc>Stuff</desc>
-		ll
-		<desc>Stuff</desc>
-		: bl
-		<desc>Stuff</desc>
-		ue
+		: bl<desc>Stuff</desc>ue
 		<desc>Stuff</desc>
 		;
-		s
+		s<desc>Stuff</desc>t<desc>Stuff</desc>r<desc>Stuff</desc>o<desc>Stuff</desc>ke:
+        gre<desc>Stuff</desc>en;
 		<desc>Stuff</desc>
-		t
-		<desc>Stuff</desc>
-		r
-		<desc>Stuff</desc>
-		o
-		<desc>Stuff</desc>
-		ke:
-		gre
-		<desc>Stuff</desc>
-		en;
-		<desc>Stuff</desc>
-		stro
-		<desc>Stuff</desc>
-		ke-
-		<desc>Stuff</desc>
-		widt
-		<desc>Stuff</desc>
-		h
+		stro<desc>Stuff</desc>ke-<desc>Stuff</desc>widt<desc>Stuff</desc>h
 		<desc>Stuff</desc>
 		: 5%;
 		<desc>Stuff</desc>

--- a/jsvg/src/test/resources/com/github/weisj/jsvg/css/brokenUpCharContent.svg
+++ b/jsvg/src/test/resources/com/github/weisj/jsvg/css/brokenUpCharContent.svg
@@ -5,40 +5,19 @@
 		class="longClassName" />
 
 	<style>
-		.l
-		<desc>Stuff</desc>
-		ongClassName
+		.l<desc>Stuff</desc>ongClassName
 		<desc>Stuff</desc>
 		{
 		<desc>Stuff</desc>
-		fi
+		fi<desc>Stuff</desc>ll
 		<desc>Stuff</desc>
-		ll
-		<desc>Stuff</desc>
-		: bl
-		<desc>Stuff</desc>
-		ue
+		: bl<desc>Stuff</desc>ue
 		<desc>Stuff</desc>
 		;
-		s
+		s<desc>Stuff</desc>t<desc>Stuff</desc>r<desc>Stuff</desc>o<desc>Stuff</desc>ke:
+        gre<desc>Stuff</desc>en;
 		<desc>Stuff</desc>
-		t
-		<desc>Stuff</desc>
-		r
-		<desc>Stuff</desc>
-		o
-		<desc>Stuff</desc>
-		ke: gre
-		<desc>Stuff</desc>
-		en;
-		<desc>Stuff</desc>
-		stro
-		<desc>Stuff</desc>
-		ke-
-		<desc>Stuff</desc>
-		widt
-		<desc>Stuff</desc>
-		h
+		stro<desc>Stuff</desc>ke-<desc>Stuff</desc>widt<desc>Stuff</desc>h
 		<desc>Stuff</desc>
 		: 5%;
 		<desc>Stuff</desc>


### PR DESCRIPTION
Provide a method to compute the shape of an `SVGDocument`. This is done by running the render pipeline with a backend that simply collects the shape of painted paths.

Closes #57 