### PR TITLE
Implement soft clipping for clip-path

### DIFF
--- a/jsvg/src/main/java/com/github/weisj/jsvg/SVGRenderingHints.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/SVGRenderingHints.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2021-2023 Jannis Weis
+ * Copyright (c) 2021-2024 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -29,10 +29,15 @@ public final class SVGRenderingHints {
     private SVGRenderingHints() {}
 
     private static final int P_KEY_IMAGE_ANTIALIASING = 1;
+    private static final int P_KEY_SOFT_CLIPPING = 2;
 
     public static final RenderingHints.Key KEY_IMAGE_ANTIALIASING = new Key(P_KEY_IMAGE_ANTIALIASING);
     public static final Object VALUE_IMAGE_ANTIALIASING_ON = Value.ON;
     public static final Object VALUE_IMAGE_ANTIALIASING_OFF = Value.OFF;
+
+    public static final RenderingHints.Key KEY_SOFT_CLIPPING = new Key(P_KEY_SOFT_CLIPPING);
+    public static final Object VALUE_SOFT_CLIPPING_ON = Value.ON;
+    public static final Object VALUE_SOFT_CLIPPING_OFF = Value.OFF;
 
     private static final class Key extends RenderingHints.Key {
         /**

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/Mask.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/Mask.java
@@ -45,6 +45,7 @@ import com.github.weisj.jsvg.renderer.Output;
 import com.github.weisj.jsvg.renderer.RenderContext;
 import com.github.weisj.jsvg.util.BlittableImage;
 import com.github.weisj.jsvg.util.ImageUtil;
+import com.github.weisj.jsvg.util.ShapeUtil;
 
 @ElementCategories(Category.Container)
 @PermittedContent(
@@ -95,10 +96,9 @@ public final class Mask extends CommonRenderableContainerNode implements Instant
                 maskBounds.createIntersection(objectBounds), objectBounds, maskContentUnits);
         Rectangle2D maskBoundsInUserSpace = blitImage.boundsInUserSpace();
 
-        if (isInvalidMaskingArea(maskBoundsInUserSpace)) return PaintParser.DEFAULT_COLOR;
+        if (ShapeUtil.isInvalidArea(maskBoundsInUserSpace)) return PaintParser.DEFAULT_COLOR;
 
         blitImage.renderNode(output, this, this);
-
 
         if (DEBUG) {
             output.debugPaint(g -> {
@@ -110,10 +110,6 @@ public final class Mask extends CommonRenderableContainerNode implements Instant
         Point2D offset = new Point2D.Double(maskBoundsInUserSpace.getX(), maskBoundsInUserSpace.getY());
         context.rootTransform().transform(offset, offset);
         return new MaskedPaint(PaintParser.DEFAULT_COLOR, blitImage.image().getRaster(), offset);
-    }
-
-    private boolean isInvalidMaskingArea(@NotNull Rectangle2D area) {
-        return area.isEmpty() || Double.isNaN(area.getWidth()) || Double.isNaN(area.getHeight());
     }
 
     @Override

--- a/jsvg/src/main/java/com/github/weisj/jsvg/renderer/NodeRenderer.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/renderer/NodeRenderer.java
@@ -146,17 +146,27 @@ public final class NodeRenderer {
                 if (!childClip.isValid()) return null;
                 if (elementBounds == null) elementBounds = elementBounds(renderable, childContext);
 
-                Shape childClipShape = childClip.clipShape(childContext, elementBounds);
+                if (output.isSoftClippingEnabled()) {
+                    if (!elementBounds.isEmpty()) {
+                        Shape childClipShape = childClip.clipShape(childContext, elementBounds, true);
 
-                if (CLIP_DEBUG) {
-                    childOutput.debugPaint(g -> {
-                        g.setClip(null);
-                        g.setPaint(Color.MAGENTA);
-                        g.draw(childClipShape);
-                    });
+                        Rectangle2D bounds = elementBounds;
+                        childOutput.setPaint(() -> childClip.createPaintForSoftClipping(
+                                childOutput, childContext, bounds, childClipShape));
+                    }
+                } else {
+                    Shape childClipShape = childClip.clipShape(childContext, elementBounds, false);
+
+                    if (CLIP_DEBUG) {
+                        childOutput.debugPaint(g -> {
+                            g.setClip(null);
+                            g.setPaint(Color.MAGENTA);
+                            g.draw(childClipShape);
+                        });
+                    }
+
+                    childOutput.applyClip(childClipShape);
                 }
-
-                childOutput.applyClip(childClipShape);
             }
         }
 

--- a/jsvg/src/main/java/com/github/weisj/jsvg/renderer/Output.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/renderer/Output.java
@@ -32,6 +32,7 @@ import java.util.function.Consumer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import com.github.weisj.jsvg.SVGRenderingHints;
 import com.github.weisj.jsvg.util.Provider;
 
 public interface Output {
@@ -106,6 +107,10 @@ public interface Output {
     boolean supportsFilters();
 
     boolean supportsColors();
+
+    default boolean isSoftClippingEnabled() {
+        return renderingHint(SVGRenderingHints.KEY_SOFT_CLIPPING) == SVGRenderingHints.VALUE_SOFT_CLIPPING_ON;
+    }
 
     interface SafeState {
         void restore();

--- a/jsvg/src/main/java/com/github/weisj/jsvg/renderer/ShapeOutput.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/renderer/ShapeOutput.java
@@ -231,6 +231,12 @@ public class ShapeOutput implements Output {
         return false;
     }
 
+    @Override
+    public boolean isSoftClippingEnabled() {
+        // Not needed here. Always return false
+        return false;
+    }
+
     private static class ShapeOutputSafeState implements SafeState {
         private final @NotNull ShapeOutput shapeOutput;
         private final @NotNull Stroke oldStroke;

--- a/jsvg/src/main/java/com/github/weisj/jsvg/util/BlittableImage.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/util/BlittableImage.java
@@ -26,6 +26,7 @@ import java.awt.geom.AffineTransform;
 import java.awt.geom.NoninvertibleTransformException;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
+import java.util.function.Consumer;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -143,6 +144,13 @@ public final class BlittableImage {
         try (NodeRenderer.Info info = NodeRenderer.createRenderInfo(node, context, imgOutput, instantiator)) {
             if (info != null) info.renderable.render(info.context, info.output());
         }
+        imgGraphics.dispose();
+    }
+
+    public void render(@NotNull Output output, @NotNull Consumer<Graphics2D> painter) {
+        Graphics2D imgGraphics = createGraphics();
+        imgGraphics.setRenderingHints(output.renderingHints());
+        painter.accept(imgGraphics);
         imgGraphics.dispose();
     }
 

--- a/jsvg/src/main/java/com/github/weisj/jsvg/util/ShapeUtil.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/util/ShapeUtil.java
@@ -33,6 +33,10 @@ public final class ShapeUtil {
 
     private ShapeUtil() {}
 
+    public static boolean isInvalidArea(@NotNull Rectangle2D area) {
+        return area.isEmpty() || Double.isNaN(area.getWidth()) || Double.isNaN(area.getHeight());
+    }
+
     /*
      * Intersect two Shapes by the simplest method, attempting to produce a simplified result. The
      * boolean arguments keep1 and keep2 specify whether or not the first or second shapes can be

--- a/jsvg/src/test/java/com/github/weisj/jsvg/ClipPathTest.java
+++ b/jsvg/src/test/java/com/github/weisj/jsvg/ClipPathTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2021-2022 Jannis Weis
+ * Copyright (c) 2021-2024 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -32,5 +32,12 @@ class ClipPathTest {
     @Test
     void tetClipPathUnits() {
         assertEquals(SUCCESS, compareImages("clipPathUnits.svg"));
+    }
+
+    @Test
+    void tetClipPathUnitsSoftClip() {
+        ReferenceTest.SOFT_CLIPPING_VALUE = SVGRenderingHints.VALUE_SOFT_CLIPPING_ON;
+        assertEquals(SUCCESS, compareImages("clipPathUnits.svg"));
+        ReferenceTest.SOFT_CLIPPING_VALUE = SVGRenderingHints.VALUE_SOFT_CLIPPING_OFF;
     }
 }

--- a/jsvg/src/test/java/com/github/weisj/jsvg/ReferenceTest.java
+++ b/jsvg/src/test/java/com/github/weisj/jsvg/ReferenceTest.java
@@ -59,6 +59,7 @@ import com.google.errorprone.annotations.CheckReturnValue;
 public final class ReferenceTest {
 
     private static final double DEFAULT_TOLERANCE = 0.5;
+    public static Object SOFT_CLIPPING_VALUE = SVGRenderingHints.VALUE_SOFT_CLIPPING_OFF;
 
     @Test
     void testIcons() {
@@ -163,7 +164,8 @@ public final class ReferenceTest {
                 RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON,
                 RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_NORMALIZE,
                 RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_ON,
-                RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY));
+                RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY,
+                SVGRenderingHints.KEY_SOFT_CLIPPING, SOFT_CLIPPING_VALUE));
     }
 
     private static BufferedImage render(@NotNull InputStream inputStream) {

--- a/jsvg/src/test/java/com/github/weisj/jsvg/SVGViewer.java
+++ b/jsvg/src/test/java/com/github/weisj/jsvg/SVGViewer.java
@@ -49,7 +49,7 @@ public final class SVGViewer {
             JFrame frame = new JFrame("SVGViewer");
 
             JComboBox<String> iconBox = new JComboBox<>(new DefaultComboBoxModel<>(findIcons()));
-            iconBox.setSelectedItem("test.svg");
+            iconBox.setSelectedItem("tmp.svg");
 
             SVGPanel svgPanel = new SVGPanel((String) Objects.requireNonNull(iconBox.getSelectedItem()));
             svgPanel.setPreferredSize(new Dimension(1000, 600));
@@ -85,6 +85,11 @@ public final class SVGViewer {
             JCheckBox paintShape = new JCheckBox("Paint SVG shape");
             paintShape.addActionListener(e -> svgPanel.setPaintSVGShape(paintShape.isSelected()));
             renderingMode.add(paintShape);
+            renderingMode.add(Box.createHorizontalStrut(5));
+
+            JCheckBox softClipping = new JCheckBox("Soft clipping");
+            softClipping.addActionListener(e -> svgPanel.setSoftClipping(softClipping.isSelected()));
+            renderingMode.add(softClipping);
             renderingMode.add(Box.createHorizontalGlue());
 
             JButton resourceInfo = new JButton("Print Memory");
@@ -135,6 +140,7 @@ public final class SVGViewer {
         };
         private final JSVGCanvas jsvgCanvas = new JSVGCanvas();
         private boolean paintShape;
+        private boolean softClipping;
 
         public SVGPanel(@NotNull String iconName) {
             selectIcon(iconName);
@@ -200,6 +206,11 @@ public final class SVGViewer {
             repaint();
         }
 
+        public void setSoftClipping(boolean softClipping) {
+            this.softClipping = softClipping;
+            repaint();
+        }
+
         @Override
         protected void paintComponent(Graphics g) {
             super.paintComponent(g);
@@ -211,6 +222,10 @@ public final class SVGViewer {
             switch (mode) {
                 case JSVG:
                     ViewBox viewBox = new ViewBox(0, 0, getWidth(), getHeight());
+                    ((Graphics2D) g).setRenderingHint(
+                            SVGRenderingHints.KEY_SOFT_CLIPPING,
+                            softClipping ? SVGRenderingHints.VALUE_SOFT_CLIPPING_ON
+                                    : SVGRenderingHints.VALUE_SOFT_CLIPPING_OFF);
                     if (paintShape) {
                         Shape shape = document.computeShape(viewBox);
                         g.setColor(Color.MAGENTA);

--- a/jsvg/src/test/resources/com/github/weisj/jsvg/clipPathUnits.svg
+++ b/jsvg/src/test/resources/com/github/weisj/jsvg/clipPathUnits.svg
@@ -21,5 +21,5 @@
 	<use clip-path="url(#myClip1)" xlink:href="#r3" fill="red" />
 
 	<!-- The last rect is clipped with objectBoundingBox units -->
-	<use clip-path="url(#myClip2)" xlink:href="#r4" fill="red" />
+	<use clip-path="url(#myClip2)" xlink:href="#r4" fill="green" />
 </svg>


### PR DESCRIPTION
For now this isn't by default and has to be enabled using SVGRenderingHints.KEY_SOFT_CLIPPING. Once I am certain the implementation behaves nicely it will be enabled based on the value of regular antialiasing rendering hint.

Relates to #59 