### PR TITLE
Introduces support for AWT components

### DIFF
--- a/jsvg/src/main/java/com/github/weisj/jsvg/SVGDocument.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/SVGDocument.java
@@ -27,6 +27,7 @@ import java.awt.geom.Path2D;
 
 import javax.swing.*;
 
+import com.github.weisj.jsvg.renderer.awt.AwtComponentPlatformSupport;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -36,7 +37,6 @@ import com.github.weisj.jsvg.geometry.size.FloatSize;
 import com.github.weisj.jsvg.geometry.size.MeasureContext;
 import com.github.weisj.jsvg.nodes.SVG;
 import com.github.weisj.jsvg.renderer.*;
-import com.github.weisj.jsvg.renderer.awt.JComponentPlatformSupport;
 import com.github.weisj.jsvg.renderer.awt.NullPlatformSupport;
 import com.github.weisj.jsvg.renderer.awt.PlatformSupport;
 
@@ -74,18 +74,27 @@ public final class SVGDocument {
     }
 
     public void render(@Nullable JComponent component, @NotNull Graphics2D graphics2D, @Nullable ViewBox bounds) {
+        render(component, graphics2D, bounds);
+    }
+
+    public void render(@Nullable Component component, @NotNull Graphics2D graphics2D, @Nullable ViewBox bounds) {
         PlatformSupport platformSupport = component != null
-                ? new JComponentPlatformSupport(component)
+                ? new AwtComponentPlatformSupport(component)
                 : new NullPlatformSupport();
+        renderWithPlatform(platformSupport, graphics2D, bounds);
+    }
+
+    private float computePlatformFontSize(@NotNull PlatformSupport platformSupport, @NotNull Output output) {
+        return output.contextFontSize().orElseGet(platformSupport::fontSize);
+    }
+
+    public void renderWithPlatform(@NotNull PlatformSupport platformSupport, @NotNull Graphics2D graphics2D,
+                                   @Nullable ViewBox bounds) {
         Graphics2D g = (Graphics2D) graphics2D.create();
         setupSVGRenderingHints(g);
         Output output = new Graphics2DOutput(g);
         renderWithPlatform(platformSupport, output, bounds);
         output.dispose();
-    }
-
-    private float computePlatformFontSize(@NotNull PlatformSupport platformSupport, @NotNull Output output) {
-        return output.contextFontSize().orElseGet(platformSupport::fontSize);
     }
 
     public void renderWithPlatform(@NotNull PlatformSupport platformSupport, @NotNull Output output,

--- a/jsvg/src/main/java/com/github/weisj/jsvg/SVGDocument.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/SVGDocument.java
@@ -73,8 +73,9 @@ public final class SVGDocument {
         render(component, g, null);
     }
 
+    @Deprecated
     public void render(@Nullable JComponent component, @NotNull Graphics2D graphics2D, @Nullable ViewBox bounds) {
-        render(component, graphics2D, bounds);
+        render((Component) component, graphics2D, bounds);
     }
 
     public void render(@Nullable Component component, @NotNull Graphics2D graphics2D, @Nullable ViewBox bounds) {

--- a/jsvg/src/main/java/com/github/weisj/jsvg/SVGDocument.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/SVGDocument.java
@@ -27,7 +27,6 @@ import java.awt.geom.Path2D;
 
 import javax.swing.*;
 
-import com.github.weisj.jsvg.renderer.awt.AwtComponentPlatformSupport;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -37,6 +36,7 @@ import com.github.weisj.jsvg.geometry.size.FloatSize;
 import com.github.weisj.jsvg.geometry.size.MeasureContext;
 import com.github.weisj.jsvg.nodes.SVG;
 import com.github.weisj.jsvg.renderer.*;
+import com.github.weisj.jsvg.renderer.awt.AwtComponentPlatformSupport;
 import com.github.weisj.jsvg.renderer.awt.NullPlatformSupport;
 import com.github.weisj.jsvg.renderer.awt.PlatformSupport;
 
@@ -90,7 +90,7 @@ public final class SVGDocument {
     }
 
     public void renderWithPlatform(@NotNull PlatformSupport platformSupport, @NotNull Graphics2D graphics2D,
-                                   @Nullable ViewBox bounds) {
+            @Nullable ViewBox bounds) {
         Graphics2D g = (Graphics2D) graphics2D.create();
         setupSVGRenderingHints(g);
         Output output = new Graphics2DOutput(g);

--- a/jsvg/src/main/java/com/github/weisj/jsvg/renderer/awt/AwtComponentPlatformSupport.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/renderer/awt/AwtComponentPlatformSupport.java
@@ -1,0 +1,49 @@
+package com.github.weisj.jsvg.renderer.awt;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.awt.*;
+import java.awt.image.ImageObserver;
+import java.awt.image.ImageProducer;
+
+public class AwtComponentPlatformSupport implements PlatformSupport {
+    protected final @NotNull Component component;
+
+    public AwtComponentPlatformSupport(@NotNull Component component) {
+        this.component = component;
+    }
+
+    @Override
+    public float fontSize() {
+        Font font = component.getFont();
+        if (font != null) return font.getSize2D();
+        return PlatformSupport.super.fontSize();
+    }
+
+    @Override
+    public @NotNull TargetSurface targetSurface() {
+        return component::repaint;
+    }
+
+    @Override
+    public boolean isLongLived() {
+        return true;
+    }
+
+    @Override
+    public @NotNull ImageObserver imageObserver() {
+        return component;
+    }
+
+    @Override
+    public @NotNull Image createImage(@NotNull ImageProducer imageProducer) {
+        return component.createImage(imageProducer);
+    }
+
+    @Override
+    public String toString() {
+        return "AwtComponentSupport{" +
+               "component=" + component +
+               '}';
+    }
+}

--- a/jsvg/src/main/java/com/github/weisj/jsvg/renderer/awt/AwtComponentPlatformSupport.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/renderer/awt/AwtComponentPlatformSupport.java
@@ -1,10 +1,31 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 Jannis Weis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
 package com.github.weisj.jsvg.renderer.awt;
-
-import org.jetbrains.annotations.NotNull;
 
 import java.awt.*;
 import java.awt.image.ImageObserver;
 import java.awt.image.ImageProducer;
+
+import org.jetbrains.annotations.NotNull;
 
 public class AwtComponentPlatformSupport implements PlatformSupport {
     protected final @NotNull Component component;
@@ -43,7 +64,7 @@ public class AwtComponentPlatformSupport implements PlatformSupport {
     @Override
     public String toString() {
         return "AwtComponentSupport{" +
-               "component=" + component +
-               '}';
+                "component=" + component +
+                '}';
     }
 }

--- a/jsvg/src/main/java/com/github/weisj/jsvg/renderer/awt/JComponentPlatformSupport.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/renderer/awt/JComponentPlatformSupport.java
@@ -21,47 +21,14 @@
  */
 package com.github.weisj.jsvg.renderer.awt;
 
-import java.awt.*;
-import java.awt.image.ImageObserver;
-import java.awt.image.ImageProducer;
-
 import javax.swing.*;
 
 import org.jetbrains.annotations.NotNull;
 
-public final class JComponentPlatformSupport implements PlatformSupport {
-
-    private final @NotNull JComponent component;
+public final class JComponentPlatformSupport extends AwtComponentPlatformSupport {
 
     public JComponentPlatformSupport(@NotNull JComponent component) {
-        this.component = component;
-    }
-
-    @Override
-    public float fontSize() {
-        Font font = component.getFont();
-        if (font != null) return font.getSize2D();
-        return PlatformSupport.super.fontSize();
-    }
-
-    @Override
-    public @NotNull TargetSurface targetSurface() {
-        return component::repaint;
-    }
-
-    @Override
-    public boolean isLongLived() {
-        return true;
-    }
-
-    @Override
-    public @NotNull ImageObserver imageObserver() {
-        return component;
-    }
-
-    @Override
-    public @NotNull Image createImage(@NotNull ImageProducer imageProducer) {
-        return component.createImage(imageProducer);
+        super(component);
     }
 
     @Override

--- a/jsvg/src/main/java/com/github/weisj/jsvg/renderer/awt/JComponentPlatformSupport.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/renderer/awt/JComponentPlatformSupport.java
@@ -25,6 +25,10 @@ import javax.swing.*;
 
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * @deprecated Use {@link AwtComponentPlatformSupport} instead.
+ */
+@Deprecated
 public final class JComponentPlatformSupport extends AwtComponentPlatformSupport {
 
     public JComponentPlatformSupport(@NotNull JComponent component) {


### PR DESCRIPTION
Possible fix for #76 

- Introduces an `AwtComponentPlatformSupport`, keep `JComponentPlatformSupport` for backward compatibility.
- Introduces a `renderWithPlatform(PlatformSupport, Graphics2D, ViewBox)` overload

Note I'm not sure about the style due t spotless plugin issues, see #78 