### PR TITLE
Introduce static singleton for NullPlatformSupport

### DIFF
--- a/jsvg/src/main/java/com/github/weisj/jsvg/SVGDocument.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/SVGDocument.java
@@ -65,7 +65,7 @@ public final class SVGDocument {
 
     public @NotNull Shape computeShape(@Nullable ViewBox viewBox) {
         Area accumulator = new Area(new Path2D.Float());
-        renderWithPlatform(new NullPlatformSupport(), new ShapeOutput(accumulator), viewBox);
+        renderWithPlatform(NullPlatformSupport.INSTANCE, new ShapeOutput(accumulator), viewBox);
         return accumulator;
     }
 
@@ -81,7 +81,7 @@ public final class SVGDocument {
     public void render(@Nullable Component component, @NotNull Graphics2D graphics2D, @Nullable ViewBox bounds) {
         PlatformSupport platformSupport = component != null
                 ? new AwtComponentPlatformSupport(component)
-                : new NullPlatformSupport();
+                : NullPlatformSupport.INSTANCE;
         renderWithPlatform(platformSupport, graphics2D, bounds);
     }
 

--- a/jsvg/src/main/java/com/github/weisj/jsvg/renderer/awt/NullPlatformSupport.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/renderer/awt/NullPlatformSupport.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023 Jannis Weis
+ * Copyright (c) 2023-2024 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -26,6 +26,15 @@ import java.awt.image.ImageObserver;
 import org.jetbrains.annotations.Nullable;
 
 public final class NullPlatformSupport implements PlatformSupport {
+    public static final NullPlatformSupport INSTANCE = new NullPlatformSupport(true);
+
+    /**
+     * @deprecated prefer {@link #INSTANCE} field usage
+     */
+    @Deprecated
+    public NullPlatformSupport() {}
+
+    private NullPlatformSupport(boolean noDeprecation) {}
 
     @Override
     public @Nullable ImageObserver imageObserver() {

--- a/jsvg/src/test/java/com/github/weisj/jsvg/BlitImageTest.java
+++ b/jsvg/src/test/java/com/github/weisj/jsvg/BlitImageTest.java
@@ -76,7 +76,7 @@ class BlitImageTest {
     @NotNull
     RenderContext createTestContext(int vw, int vh) {
         return RenderContext.createInitial(
-                new NullPlatformSupport(),
+                NullPlatformSupport.INSTANCE,
                 new MeasureContext(vw, vh,
                         SVGFont.defaultFontSize(),
                         SVGFont.exFromEm(SVGFont.defaultFontSize())));

--- a/jsvg/src/test/java/com/github/weisj/jsvg/ToShapeTest.java
+++ b/jsvg/src/test/java/com/github/weisj/jsvg/ToShapeTest.java
@@ -160,7 +160,7 @@ class ToShapeTest {
         Graphics2D g = img.createGraphics();
         g.setColor(Color.BLACK);
         document.renderWithPlatform(
-                new NullPlatformSupport(),
+                NullPlatformSupport.INSTANCE,
                 new BlackAndWhiteOutput(g),
                 new ViewBox(0, 0, img.getWidth(), img.getHeight()));
         g.dispose();

--- a/jsvg/src/test/java/com/github/weisj/jsvg/parser/UIFutureTest.java
+++ b/jsvg/src/test/java/com/github/weisj/jsvg/parser/UIFutureTest.java
@@ -39,7 +39,7 @@ class UIFutureTest {
     void testValueUiFuture() {
         Object o = new Object();
         UIFuture<Object> future = new ValueUIFuture<>(o);
-        assertTrue(future.checkIfReady(new NullPlatformSupport()));
+        assertTrue(future.checkIfReady(NullPlatformSupport.INSTANCE));
         assertEquals(o, future.get());
     }
 


### PR DESCRIPTION
Since NullPlatformSupport is final, and we can make singleton of it, and replace all usages.

Old constructor deprecated (backward compatibility) 