### PR TITLE
Fix dashPattern annotation in StrokeContext

### DIFF
--- a/jsvg/src/main/java/com/github/weisj/jsvg/renderer/impl/context/StrokeContext.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/renderer/impl/context/StrokeContext.java
@@ -47,7 +47,7 @@ public final class StrokeContext {
     public final @Nullable LengthValue dashOffset;
 
     public StrokeContext(@Nullable LengthValue strokeWidth, @Nullable LineCap lineCap, @Nullable LineJoin lineJoin,
-            float miterLimit, @NotNull Length[] dashPattern, @Nullable LengthValue dashOffset) {
+            float miterLimit, Length @Nullable [] dashPattern, @Nullable LengthValue dashOffset) {
         this.strokeWidth = strokeWidth;
         this.lineCap = lineCap;
         this.lineJoin = lineJoin;


### PR DESCRIPTION
Hey

This is a really tiny PR as only just starting playing with your library!
Just bringing to your attention as unit tests were failing for me, due to the ``@NotNull`` annotation on dashPattern in stroke context, though null is handled in ``validateDashPattern()`` so switched to a ``@Nullable`` annotation

Ollie