### PR TITLE
Fix #151: Allow mixed comma and whitespace separation in transform pa…

### DIFF
--- a/jsvg/src/main/java/com/github/weisj/jsvg/parser/impl/ParserUtil.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/parser/impl/ParserUtil.java
@@ -117,7 +117,7 @@ public final class ParserUtil {
             inWhiteSpace = false;
             ListSplitter.SplitResult result = splitter.testChar(c, i - start);
             if (result.shouldSplit()) {
-                list.add(value.substring(start, i));
+                if (i - start > 0)  list.add(value.substring(start, i));
                 start = result.shouldIncludeChar() ? i : i + 1;
             }
         }

--- a/jsvg/src/main/java/com/github/weisj/jsvg/parser/impl/ParserUtil.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/parser/impl/ParserUtil.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2025 Jannis Weis
+ * Copyright (c) 2025-2026 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -101,15 +101,18 @@ public final class ParserUtil {
         if (value == null || value.isEmpty()) return fallback;
         List<String> list = new ArrayList<>();
         int max = value.length();
+        boolean splitOnWhitespace = splitter.splitOnWhitespace();
         int start = 0;
         int i = 0;
         boolean inWhiteSpace = false;
+        boolean lastSplitWasWhiteSpace = false;
         for (; i < max; i++) {
             char c = value.charAt(i);
             if (Character.isWhitespace(c)) {
-                if (!inWhiteSpace && splitter.splitOnWhitespace() && i - start > 0) {
+                if (!inWhiteSpace && splitOnWhitespace && i - start > 0) {
                     list.add(value.substring(start, i));
                     start = i + 1;
+                    lastSplitWasWhiteSpace = true;
                 }
                 inWhiteSpace = true;
                 continue;
@@ -117,9 +120,12 @@ public final class ParserUtil {
             inWhiteSpace = false;
             ListSplitter.SplitResult result = splitter.testChar(c, i - start);
             if (result.shouldSplit()) {
-                if (i - start > 0)  list.add(value.substring(start, i));
+                if (!(lastSplitWasWhiteSpace && i == start)) list.add(value.substring(start, i));
                 start = result.shouldIncludeChar() ? i : i + 1;
+                lastSplitWasWhiteSpace = false;
+                continue;
             }
+            lastSplitWasWhiteSpace = false;
         }
         if (i - start > 0) list.add(value.substring(start, i));
         return list.toArray(new String[0]);

--- a/jsvg/src/main/java/com/github/weisj/jsvg/parser/impl/ParserUtil.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/parser/impl/ParserUtil.java
@@ -31,6 +31,7 @@ import org.jetbrains.annotations.Nullable;
 
 import com.github.weisj.jsvg.geometry.size.Length;
 import com.github.weisj.jsvg.geometry.size.Unit;
+import com.github.weisj.jsvg.parser.NumberListSplitter;
 import com.github.weisj.jsvg.util.ParserBase;
 
 public final class ParserUtil {
@@ -102,6 +103,7 @@ public final class ParserUtil {
         List<String> list = new ArrayList<>();
         int max = value.length();
         boolean splitOnWhitespace = splitter.splitOnWhitespace();
+        boolean trimTokens = splitOnWhitespace && splitter instanceof NumberListSplitter;
         int start = 0;
         int i = 0;
         boolean inWhiteSpace = false;
@@ -110,7 +112,9 @@ public final class ParserUtil {
             char c = value.charAt(i);
             if (Character.isWhitespace(c)) {
                 if (!inWhiteSpace && splitOnWhitespace && i - start > 0) {
-                    list.add(value.substring(start, i));
+                    String token = value.substring(start, i);
+                    if (trimTokens) token = token.trim();
+                    list.add(token);
                     start = i + 1;
                     lastSplitWasWhiteSpace = true;
                 }
@@ -120,14 +124,22 @@ public final class ParserUtil {
             inWhiteSpace = false;
             ListSplitter.SplitResult result = splitter.testChar(c, i - start);
             if (result.shouldSplit()) {
-                if (!(lastSplitWasWhiteSpace && i == start)) list.add(value.substring(start, i));
+                if (!(lastSplitWasWhiteSpace && i == start)) {
+                    String token = value.substring(start, i);
+                    if (trimTokens) token = token.trim();
+                    list.add(token);
+                }
                 start = result.shouldIncludeChar() ? i : i + 1;
                 lastSplitWasWhiteSpace = false;
                 continue;
             }
             lastSplitWasWhiteSpace = false;
         }
-        if (i - start > 0) list.add(value.substring(start, i));
+        if (i - start > 0) {
+            String token = value.substring(start, i);
+            if (trimTokens) token = token.trim();
+            list.add(token);
+        }
         return list.toArray(new String[0]);
     }
 }

--- a/jsvg/src/test/java/com/github/weisj/jsvg/attribute/AttributeParserTest.java
+++ b/jsvg/src/test/java/com/github/weisj/jsvg/attribute/AttributeParserTest.java
@@ -22,7 +22,10 @@
 package com.github.weisj.jsvg.attribute;
 
 import java.util.Random;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 
+import com.github.weisj.jsvg.parser.NumberListSplitter;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -50,6 +53,21 @@ class AttributeParserTest {
     @Test
     void testStringListRequiredComma() {
         testStringList(true);
+    }
+
+    @Test
+    void testNumberSplitter() {
+        BiConsumer<String, String[]> test = (str, expected) -> {
+            String[] result = parser.parseStringList(str, NumberListSplitter.INSTANCE);
+            Assertions.assertArrayEquals(expected, result);
+        };
+        test.accept("1,1", new String[] {"1", "1"});
+        test.accept("1 1", new String[] {"1", "1"});
+        test.accept("1-1", new String[] {"1", "-1"});
+        test.accept("1, 1", new String[] {"1", "1"});
+        test.accept("1,  1", new String[] {"1", "1"});
+        test.accept("1 , 1", new String[] {"1", "1"});
+        test.accept("1, ,1", new String[] {"1", "", "1"});
     }
 
     @Test

--- a/jsvg/src/test/java/com/github/weisj/jsvg/attribute/AttributeParserTest.java
+++ b/jsvg/src/test/java/com/github/weisj/jsvg/attribute/AttributeParserTest.java
@@ -23,6 +23,7 @@ package com.github.weisj.jsvg.attribute;
 
 import java.util.Random;
 
+import com.github.weisj.jsvg.attributes.transform.TransformPart;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -91,4 +92,17 @@ class AttributeParserTest {
         }
         return builder.toString();
     }
+
+    @Test
+    void testTransformScaleAllowsCommaAndWhitespace() {
+        TransformPart part = parser.parseTransformPart(TransformPart.TransformType.SCALE, "-1, 1");
+        Assertions.assertNotNull(part);
+    }
+
+    @Test
+    void testTransformScaleAllowsMixedCommaAndWhitespace() {
+        TransformPart part = parser.parseTransformPart(TransformPart.TransformType.SCALE, "-1 , 1");
+        Assertions.assertNotNull(part);
+    }
+
 }

--- a/jsvg/src/test/java/com/github/weisj/jsvg/attribute/AttributeParserTest.java
+++ b/jsvg/src/test/java/com/github/weisj/jsvg/attribute/AttributeParserTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2021-2025 Jannis Weis
+ * Copyright (c) 2021-2026 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -23,11 +23,11 @@ package com.github.weisj.jsvg.attribute;
 
 import java.util.Random;
 
-import com.github.weisj.jsvg.attributes.transform.TransformPart;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.github.weisj.jsvg.attributes.transform.TransformPart;
 import com.github.weisj.jsvg.paint.impl.DefaultPaintParser;
 import com.github.weisj.jsvg.parser.impl.AttributeParser;
 import com.github.weisj.jsvg.parser.impl.SeparatorMode;
@@ -105,4 +105,9 @@ class AttributeParserTest {
         Assertions.assertNotNull(part);
     }
 
+    @Test
+    void testTransformCommaOnlyKeepsEmptyEntryBetweenCommas() {
+        String[] values = parser.parseStringList("1,,1", SeparatorMode.COMMA_ONLY);
+        Assertions.assertArrayEquals(new String[] {"1", "", "1"}, values);
+    }
 }

--- a/jsvg/src/test/java/com/github/weisj/jsvg/attribute/AttributeParserTest.java
+++ b/jsvg/src/test/java/com/github/weisj/jsvg/attribute/AttributeParserTest.java
@@ -23,15 +23,13 @@ package com.github.weisj.jsvg.attribute;
 
 import java.util.Random;
 import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
 
-import com.github.weisj.jsvg.parser.NumberListSplitter;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import com.github.weisj.jsvg.attributes.transform.TransformPart;
 import com.github.weisj.jsvg.paint.impl.DefaultPaintParser;
+import com.github.weisj.jsvg.parser.NumberListSplitter;
 import com.github.weisj.jsvg.parser.impl.AttributeParser;
 import com.github.weisj.jsvg.parser.impl.SeparatorMode;
 import com.github.weisj.jsvg.util.RandomData;
@@ -111,21 +109,4 @@ class AttributeParserTest {
         return builder.toString();
     }
 
-    @Test
-    void testTransformScaleAllowsCommaAndWhitespace() {
-        TransformPart part = parser.parseTransformPart(TransformPart.TransformType.SCALE, "-1, 1");
-        Assertions.assertNotNull(part);
-    }
-
-    @Test
-    void testTransformScaleAllowsMixedCommaAndWhitespace() {
-        TransformPart part = parser.parseTransformPart(TransformPart.TransformType.SCALE, "-1 , 1");
-        Assertions.assertNotNull(part);
-    }
-
-    @Test
-    void testTransformCommaOnlyKeepsEmptyEntryBetweenCommas() {
-        String[] values = parser.parseStringList("1,,1", SeparatorMode.COMMA_ONLY);
-        Assertions.assertArrayEquals(new String[] {"1", "", "1"}, values);
-    }
 }


### PR DESCRIPTION
Modified ParserUtil.java to add a guard `if (i - start > 0)` before adding tokens to the list. This ensures that consecutive separators (e.g., "-1 ,  1") do not produce empty strings, which previously caused parsing failures.

Added two tests in AttributeParserTest.java:
- scale(-1, 1) : Comma separator.
- scale(-1 , 1) : Mixed space and comma separator.
Both tests now pass correctly.

This is my first pr. Please let me know if anything needs to be adjusted!