### PR TITLE
Add support for FeDiffuseLighting filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ For supported elements most of the attributes which apply to them are implemente
 | feConvolveMatrix    | :x:                     |
 | feDiffuseLighting   | :white_check_mark:      |
 | feDisplacementMap   | :white_check_mark:      |
-| feDistantLight      | :x:                     |
+| feDistantLight      | :white_check_mark:      |
 | feDropShadow        | :white_check_mark:      |
 | feFlood             | :white_check_mark:      |
 | feFuncA             | :white_check_mark:      |
@@ -334,9 +334,9 @@ For supported elements most of the attributes which apply to them are implemente
 | feMergeNode         | :white_check_mark:      |
 | feMorphology        | :x:                     |
 | feOffset            | :white_check_mark:      |
-| fePointLight        | :x:                     |
+| fePointLight        | :white_check_mark:      |
 | feSpecularLighting  | :x:                     |
-| feSpotLight         | :x:                     |
+| feSpotLight         | :white_check_mark:      |
 | feTile              | :x:                     |
 | feTurbulence        | :white_check_mark:      |
 | filter              | :ballot_box_with_check: |

--- a/jsvg-javafx/src/test/java/com/github/weisj/jsvg/renderer/jfx/FXOutputTest.java
+++ b/jsvg-javafx/src/test/java/com/github/weisj/jsvg/renderer/jfx/FXOutputTest.java
@@ -108,6 +108,8 @@ class FXOutputTest {
             "topRight.svg",
             "unknown.svg",
             "dropShadow.svg",
+            "diffuseLighting.svg",
+            "diffuseLighting_issue167.svg",
             "composite.svg",
             "turbulence1.svg",
             "turbulence2.svg",

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/CompositeModeComposite.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/CompositeModeComposite.java
@@ -57,10 +57,10 @@ public final class CompositeModeComposite {
                 return new LighterComposite();
             case Arithmetic:
                 return new ArithmeticComposite(
-                        attributeNode.getInt("k1", 0),
-                        attributeNode.getInt("k2", 0),
-                        attributeNode.getInt("k3", 0),
-                        attributeNode.getInt("k4", 0));
+                        attributeNode.getFloat("k1", 0),
+                        attributeNode.getFloat("k2", 0),
+                        attributeNode.getFloat("k3", 0),
+                        attributeNode.getFloat("k4", 0));
             default:
                 throw new IllegalStateException();
         }
@@ -69,12 +69,12 @@ public final class CompositeModeComposite {
     private static final class ArithmeticComposite extends AbstractBlendComposite
             implements AbstractBlendComposite.Blender {
 
-        private final int k1;
-        private final int k2;
-        private final int k3;
-        private final int k4;
+        private final float k1;
+        private final float k2;
+        private final float k3;
+        private final float k4;
 
-        private ArithmeticComposite(int k1, int k2, int k3, int k4) {
+        private ArithmeticComposite(float k1, float k2, float k3, float k4) {
             this.k1 = k1;
             this.k2 = k2;
             this.k3 = k3;
@@ -88,10 +88,16 @@ public final class CompositeModeComposite {
 
         @Override
         public void blend(int @NotNull [] src, int @NotNull [] dst, int @NotNull [] result) {
-            result[0] = Math.max(0, Math.min(255, k1 * src[0] * dst[0] + k2 * src[0] + k3 * dst[0] + k4));
-            result[1] = Math.max(0, Math.min(255, k1 * src[1] * dst[1] + k2 * src[1] + k3 * dst[1] + k4));
-            result[2] = Math.max(0, Math.min(255, k1 * src[2] * dst[2] + k2 * src[2] + k3 * dst[2] + k4));
-            result[3] = Math.max(0, Math.min(255, k1 * src[3] * dst[3] + k2 * src[3] + k3 * dst[3] + k4));
+            result[0] = arithmetic(src[0], dst[0]);
+            result[1] = arithmetic(src[1], dst[1]);
+            result[2] = arithmetic(src[2], dst[2]);
+            result[3] = arithmetic(src[3], dst[3]);
+        }
+
+        private int arithmetic(int src, int dst) {
+            double s = src / 255.0;
+            double d = dst / 255.0;
+            return Math.max(0, Math.min(255, (int) Math.round(255 * (k1 * s * d + k2 * s + k3 * d + k4))));
         }
     }
 

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/CompositeModeComposite.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/CompositeModeComposite.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023-2025 Jannis Weis
+ * Copyright (c) 2023-2026 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/FeDiffuseLighting.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/FeDiffuseLighting.java
@@ -26,6 +26,8 @@ import java.awt.color.ColorSpace;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.*;
+import java.util.Collections;
+import java.util.List;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -33,10 +35,12 @@ import org.jetbrains.annotations.Nullable;
 import com.github.weisj.jsvg.attributes.ColorInterpolation;
 import com.github.weisj.jsvg.attributes.filter.LayoutBounds;
 import com.github.weisj.jsvg.geometry.size.FloatInsets;
+import com.github.weisj.jsvg.logging.Logger;
+import com.github.weisj.jsvg.logging.impl.LogFactory;
 import com.github.weisj.jsvg.nodes.SVGNode;
 import com.github.weisj.jsvg.nodes.animation.Animate;
 import com.github.weisj.jsvg.nodes.animation.Set;
-import com.github.weisj.jsvg.nodes.container.ContainerNode;
+import com.github.weisj.jsvg.nodes.prototype.Container;
 import com.github.weisj.jsvg.nodes.prototype.spec.Category;
 import com.github.weisj.jsvg.nodes.prototype.spec.ElementCategories;
 import com.github.weisj.jsvg.nodes.prototype.spec.PermittedContent;
@@ -47,17 +51,19 @@ import com.github.weisj.jsvg.util.ImageUtil;
 
 @ElementCategories(Category.FilterPrimitive)
 @PermittedContent(
-    anyOf = {FeDistantLight.class, FePointLight.class, FeSpotLight.class, Animate.class, Set.class}
+    categories = {Category.LightSource},
+    anyOf = {Animate.class, Set.class}
 )
-public final class FeDiffuseLighting extends ContainerNode implements FilterPrimitive {
+public final class FeDiffuseLighting extends AbstractFilterPrimitive implements Container<LightSource> {
     public static final String TAG = "fediffuselighting";
 
-    private FilterPrimitiveBase filterPrimitiveBase;
+    private static final Logger LOGGER = LogFactory.createLogger(FeDiffuseLighting.class);
 
     private float surfaceScale;
     private float diffuseConstant;
     private Color lightingColor;
     private double @Nullable [] kernelUnitLength;
+    private @Nullable LightSource lightSource;
 
     @Override
     public @NotNull String tagName() {
@@ -68,7 +74,6 @@ public final class FeDiffuseLighting extends ContainerNode implements FilterPrim
     public void build(@NotNull AttributeNode attributeNode) {
         super.build(attributeNode);
 
-        filterPrimitiveBase = new FilterPrimitiveBase(attributeNode);
         surfaceScale = attributeNode.getFloat("surfaceScale", 1);
         diffuseConstant = attributeNode.getNonNegativeFloat("diffuseConstant", 1);
         lightingColor = attributeNode.getColor("lighting-color", Color.WHITE);
@@ -83,33 +88,22 @@ public final class FeDiffuseLighting extends ContainerNode implements FilterPrim
         }
     }
 
-    private @NotNull FilterPrimitiveBase impl() {
-        return filterPrimitiveBase;
+    @Override
+    public void addChild(@Nullable String id, @NotNull SVGNode node) {
+        if (node instanceof LightSource) {
+            if (lightSource != null) {
+                LOGGER.log(Logger.Level.WARNING,
+                        "Element <fediffuselighting> should only have one light source. Using the first one.");
+            } else {
+                lightSource = (LightSource) node;
+            }
+        }
     }
 
     @Override
-    public @NotNull com.github.weisj.jsvg.geometry.size.Length x() {
-        return impl().x;
-    }
-
-    @Override
-    public @NotNull com.github.weisj.jsvg.geometry.size.Length y() {
-        return impl().y;
-    }
-
-    @Override
-    public @NotNull com.github.weisj.jsvg.geometry.size.Length width() {
-        return impl().width;
-    }
-
-    @Override
-    public @NotNull com.github.weisj.jsvg.geometry.size.Length height() {
-        return impl().height;
-    }
-
-    @Override
-    protected boolean acceptChild(@Nullable String id, @NotNull SVGNode node) {
-        return node instanceof LightSource && super.acceptChild(id, node);
+    public @NotNull List<? extends @NotNull LightSource> children() {
+        if (lightSource == null) return Collections.emptyList();
+        return Collections.singletonList(lightSource);
     }
 
     @Override
@@ -122,7 +116,6 @@ public final class FeDiffuseLighting extends ContainerNode implements FilterPrim
 
     @Override
     public void applyFilter(@NotNull RenderContext context, @NotNull FilterContext filterContext) {
-        LightSource lightSource = lightSource();
         if (lightSource == null) {
             Filter.FilterInfo info = filterContext.info();
             BufferedImage img = new BufferedImage(info.imageWidth, info.imageHeight, BufferedImage.TYPE_INT_ARGB);
@@ -133,18 +126,6 @@ public final class FeDiffuseLighting extends ContainerNode implements FilterPrim
         ImageFilter lightingFilter = new BufferedImageFilter(
                 new DiffuseLightingOp(lightSource, filterContext.info().tile(), colorInterpolation(filterContext)));
         impl().saveResult(impl().inputChannel(filterContext).applyFilter(lightingFilter), filterContext);
-    }
-
-    private @Nullable LightSource lightSource() {
-        for (SVGNode node : children()) {
-            if (node instanceof LightSource) return (LightSource) node;
-        }
-        return null;
-    }
-
-    @Override
-    public ColorInterpolation colorInterpolation(@NotNull FilterContext filterContext) {
-        return impl().colorInterpolation(filterContext);
     }
 
     private final class DiffuseLightingOp implements BufferedImageOp {

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/FeDiffuseLighting.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/FeDiffuseLighting.java
@@ -1,0 +1,299 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Jannis Weis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package com.github.weisj.jsvg.nodes.filter;
+
+import java.awt.*;
+import java.awt.color.ColorSpace;
+import java.awt.geom.Point2D;
+import java.awt.geom.Rectangle2D;
+import java.awt.image.*;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import com.github.weisj.jsvg.attributes.ColorInterpolation;
+import com.github.weisj.jsvg.attributes.filter.LayoutBounds;
+import com.github.weisj.jsvg.geometry.size.FloatInsets;
+import com.github.weisj.jsvg.nodes.SVGNode;
+import com.github.weisj.jsvg.nodes.animation.Animate;
+import com.github.weisj.jsvg.nodes.animation.Set;
+import com.github.weisj.jsvg.nodes.container.ContainerNode;
+import com.github.weisj.jsvg.nodes.prototype.spec.Category;
+import com.github.weisj.jsvg.nodes.prototype.spec.ElementCategories;
+import com.github.weisj.jsvg.nodes.prototype.spec.PermittedContent;
+import com.github.weisj.jsvg.parser.impl.AttributeNode;
+import com.github.weisj.jsvg.renderer.RenderContext;
+import com.github.weisj.jsvg.util.ColorUtil;
+import com.github.weisj.jsvg.util.ImageUtil;
+
+@ElementCategories(Category.FilterPrimitive)
+@PermittedContent(
+    anyOf = {FeDistantLight.class, FePointLight.class, FeSpotLight.class, Animate.class, Set.class}
+)
+public final class FeDiffuseLighting extends ContainerNode implements FilterPrimitive {
+    public static final String TAG = "fediffuselighting";
+
+    private FilterPrimitiveBase filterPrimitiveBase;
+
+    private float surfaceScale;
+    private float diffuseConstant;
+    private Color lightingColor;
+    private double @Nullable [] kernelUnitLength;
+
+    @Override
+    public @NotNull String tagName() {
+        return TAG;
+    }
+
+    @Override
+    public void build(@NotNull AttributeNode attributeNode) {
+        super.build(attributeNode);
+
+        filterPrimitiveBase = new FilterPrimitiveBase(attributeNode);
+        surfaceScale = attributeNode.getFloat("surfaceScale", 1);
+        diffuseConstant = attributeNode.getNonNegativeFloat("diffuseConstant", 1);
+        lightingColor = attributeNode.getColor("lighting-color", Color.WHITE);
+
+        double[] values = attributeNode.getDoubleList("kernelUnitLength");
+        if (values.length > 0 && values[0] > 0) {
+            double x = values[0];
+            double y = values.length > 1 && values[1] > 0 ? values[1] : x;
+            kernelUnitLength = new double[] {x, y};
+        } else {
+            kernelUnitLength = null;
+        }
+    }
+
+    private @NotNull FilterPrimitiveBase impl() {
+        return filterPrimitiveBase;
+    }
+
+    @Override
+    public @NotNull com.github.weisj.jsvg.geometry.size.Length x() {
+        return impl().x;
+    }
+
+    @Override
+    public @NotNull com.github.weisj.jsvg.geometry.size.Length y() {
+        return impl().y;
+    }
+
+    @Override
+    public @NotNull com.github.weisj.jsvg.geometry.size.Length width() {
+        return impl().width;
+    }
+
+    @Override
+    public @NotNull com.github.weisj.jsvg.geometry.size.Length height() {
+        return impl().height;
+    }
+
+    @Override
+    protected boolean acceptChild(@Nullable String id, @NotNull SVGNode node) {
+        return node instanceof LightSource && super.acceptChild(id, node);
+    }
+
+    @Override
+    public void layoutFilter(@NotNull RenderContext context, @NotNull FilterLayoutContext filterLayoutContext) {
+        LayoutBounds layoutBounds = new LayoutBounds(
+                filterLayoutContext.filterPrimitiveRegion(context.measureContext(), this),
+                new FloatInsets());
+        impl().saveLayoutResult(layoutBounds, filterLayoutContext);
+    }
+
+    @Override
+    public void applyFilter(@NotNull RenderContext context, @NotNull FilterContext filterContext) {
+        LightSource lightSource = lightSource();
+        if (lightSource == null) {
+            Filter.FilterInfo info = filterContext.info();
+            BufferedImage img = new BufferedImage(info.imageWidth, info.imageHeight, BufferedImage.TYPE_INT_ARGB);
+            impl().saveResult(new ImageProducerChannel(img.getSource()), filterContext);
+            return;
+        }
+
+        ImageFilter lightingFilter = new BufferedImageFilter(
+                new DiffuseLightingOp(lightSource, filterContext.info().tile(), colorInterpolation(filterContext)));
+        impl().saveResult(impl().inputChannel(filterContext).applyFilter(lightingFilter), filterContext);
+    }
+
+    private @Nullable LightSource lightSource() {
+        for (SVGNode node : children()) {
+            if (node instanceof LightSource) return (LightSource) node;
+        }
+        return null;
+    }
+
+    @Override
+    public ColorInterpolation colorInterpolation(@NotNull FilterContext filterContext) {
+        return impl().colorInterpolation(filterContext);
+    }
+
+    private final class DiffuseLightingOp implements BufferedImageOp {
+
+        private final @NotNull LightSource lightSource;
+        private final @NotNull Rectangle2D sourceBounds;
+        private final @Nullable ColorInterpolation colorInterpolation;
+
+        private DiffuseLightingOp(@NotNull LightSource lightSource, @NotNull Rectangle2D sourceBounds,
+                @Nullable ColorInterpolation colorInterpolation) {
+            this.lightSource = lightSource;
+            this.sourceBounds = sourceBounds;
+            this.colorInterpolation = colorInterpolation;
+        }
+
+        @Override
+        public BufferedImage createCompatibleDestImage(BufferedImage src, ColorModel dstCM) {
+            if (dstCM == null) dstCM = src.getColorModel();
+            return new BufferedImage(dstCM, dstCM.createCompatibleWritableRaster(src.getWidth(), src.getHeight()),
+                    dstCM.isAlphaPremultiplied(), null);
+        }
+
+        @Override
+        public Rectangle2D getBounds2D(@NotNull BufferedImage src) {
+            return new Rectangle(0, 0, src.getWidth(), src.getHeight());
+        }
+
+        @Override
+        public Point2D getPoint2D(Point2D srcPt, Point2D dstPt) {
+            return (Point2D) srcPt.clone();
+        }
+
+        @Override
+        public BufferedImage filter(BufferedImage src, BufferedImage dest) {
+            if (src == null) throw new NullPointerException("src image is null");
+            if (src == dest) throw new IllegalArgumentException("src image cannot be the same as the dst image");
+
+            BufferedImage result = dest;
+            if (result == null) {
+                ColorSpace cs = ColorSpace.getInstance(ColorSpace.CS_sRGB);
+                ColorModel cm = new DirectColorModel(cs, 32, 0x00FF0000, 0x0000FF00, 0x000000FF, 0xFF000000,
+                        false, DataBuffer.TYPE_INT);
+                result = createCompatibleDestImage(src, cm);
+            }
+
+            WritableRaster raster = result.getRaster();
+            int w = raster.getWidth();
+            int h = raster.getHeight();
+            double scaleX = sourceBounds.getWidth() / w;
+            double scaleY = sourceBounds.getHeight() / h;
+            double startX = sourceBounds.getX();
+            double startY = sourceBounds.getY();
+
+            double pixelStepX = 1;
+            double pixelStepY = 1;
+            double userStepX = scaleX;
+            double userStepY = scaleY;
+            if (kernelUnitLength != null) {
+                pixelStepX = kernelUnitLength[0] / scaleX;
+                pixelStepY = kernelUnitLength[1] / scaleY;
+                userStepX = kernelUnitLength[0];
+                userStepY = kernelUnitLength[1];
+            }
+
+            int[] lightColor = {lightingColor.getRed(), lightingColor.getGreen(), lightingColor.getBlue(), 255};
+            boolean linearRGB = colorInterpolation != ColorInterpolation.S_RGB;
+            if (linearRGB) ColorUtil.sRGBtoLinearRGBinPlace(lightColor);
+
+            final int[] destPixels = ImageUtil.getINT_RGBA_DataBank(raster);
+            final int dstAdjust = ImageUtil.getINT_RGBA_DataAdjust(raster);
+            int dp = ImageUtil.getINT_RGBA_DataOffset(raster);
+
+            double userY = startY;
+            for (int y = 0; y < h; y++) {
+                double userX = startX;
+                for (int x = 0, end = dp + w; dp < end; dp++, x++) {
+                    double z = heightAt(src, x, y);
+                    Normal normal = normalAt(src, x, y, pixelStepX, pixelStepY, userStepX, userStepY);
+                    LightSource.Light light = lightSource.lightAt(userX, userY, z);
+                    double diffuse = diffuseConstant * light.intensity *
+                            Math.max(0, normal.x * light.x + normal.y * light.y + normal.z * light.z);
+
+                    int r = ColorUtil.toRgbRange(lightColor[0] * diffuse);
+                    int g = ColorUtil.toRgbRange(lightColor[1] * diffuse);
+                    int b = ColorUtil.toRgbRange(lightColor[2] * diffuse);
+                    if (linearRGB) {
+                        r = ColorUtil.linearRGBtoSRGBBand(r);
+                        g = ColorUtil.linearRGBtoSRGBBand(g);
+                        b = ColorUtil.linearRGBtoSRGBBand(b);
+                    }
+                    destPixels[dp] = (0xFF << 24) | (r << 16) | (g << 8) | b;
+                    userX += scaleX;
+                }
+                userY += scaleY;
+                dp += dstAdjust;
+            }
+            return result;
+        }
+
+        private double heightAt(@NotNull BufferedImage src, double x, double y) {
+            return surfaceScale * alphaAt(src, x, y) / 255.0;
+        }
+
+        private double alphaAt(@NotNull BufferedImage src, double x, double y) {
+            double clampedX = Math.max(0, Math.min(src.getWidth() - 1, x));
+            double clampedY = Math.max(0, Math.min(src.getHeight() - 1, y));
+            int x0 = (int) Math.floor(clampedX);
+            int y0 = (int) Math.floor(clampedY);
+            int x1 = Math.min(src.getWidth() - 1, x0 + 1);
+            int y1 = Math.min(src.getHeight() - 1, y0 + 1);
+            double tx = clampedX - x0;
+            double ty = clampedY - y0;
+
+            double a00 = (src.getRGB(x0, y0) >>> 24) & 0xFF;
+            double a10 = (src.getRGB(x1, y0) >>> 24) & 0xFF;
+            double a01 = (src.getRGB(x0, y1) >>> 24) & 0xFF;
+            double a11 = (src.getRGB(x1, y1) >>> 24) & 0xFF;
+            double a0 = a00 + (a10 - a00) * tx;
+            double a1 = a01 + (a11 - a01) * tx;
+            return a0 + (a1 - a0) * ty;
+        }
+
+        private @NotNull Normal normalAt(@NotNull BufferedImage src, int x, int y, double pixelStepX,
+                double pixelStepY, double userStepX, double userStepY) {
+            double dx = (heightAt(src, x + pixelStepX, y) - heightAt(src, x - pixelStepX, y)) / (2 * userStepX);
+            double dy = (heightAt(src, x, y + pixelStepY) - heightAt(src, x, y - pixelStepY)) / (2 * userStepY);
+
+            double nx = -dx;
+            double ny = -dy;
+            double nz = 1;
+            double length = Math.sqrt(nx * nx + ny * ny + nz * nz);
+            return new Normal(nx / length, ny / length, nz / length);
+        }
+
+        @Override
+        public RenderingHints getRenderingHints() {
+            return null;
+        }
+    }
+
+    private static final class Normal {
+        final double x;
+        final double y;
+        final double z;
+
+        private Normal(double x, double y, double z) {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+        }
+    }
+}

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/FeDiffuseLighting.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/FeDiffuseLighting.java
@@ -124,7 +124,8 @@ public final class FeDiffuseLighting extends AbstractFilterPrimitive implements 
         }
 
         ImageFilter lightingFilter = new BufferedImageFilter(
-                new DiffuseLightingOp(lightSource, filterContext.info().tile(), colorInterpolation(filterContext)));
+                new DiffuseLightingOp(lightSource, filterContext.info().imageBounds(),
+                        colorInterpolation(filterContext)));
         impl().saveResult(impl().inputChannel(filterContext).applyFilter(lightingFilter), filterContext);
     }
 

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/FeDisplacementMap.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/FeDisplacementMap.java
@@ -34,7 +34,6 @@ import com.github.weisj.jsvg.attributes.filter.ColorChannel;
 import com.github.weisj.jsvg.attributes.filter.DefaultFilterChannel;
 import com.github.weisj.jsvg.attributes.filter.FilterChannelKey;
 import com.github.weisj.jsvg.attributes.filter.LayoutBounds;
-import com.github.weisj.jsvg.geometry.size.FloatInsets;
 import com.github.weisj.jsvg.nodes.animation.Animate;
 import com.github.weisj.jsvg.nodes.animation.Set;
 import com.github.weisj.jsvg.nodes.prototype.spec.Category;

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/FeDisplacementMap.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/FeDisplacementMap.java
@@ -76,6 +76,8 @@ public final class FeDisplacementMap extends AbstractFilterPrimitive {
 
     @Override
     public void layoutFilter(@NotNull RenderContext context, @NotNull FilterLayoutContext filterLayoutContext) {
+        // The displacement formula maps channel values from [0, 1] to [-0.5, 0.5],
+        // so the maximum lookup offset is half of the configured scale in either direction.
         float grow = Math.abs(scale) / 2f;
         LayoutBounds layoutBounds = impl().layoutInput(filterLayoutContext).grow(grow, grow, filterLayoutContext);
         impl().saveLayoutResult(layoutBounds, filterLayoutContext);

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/FeDisplacementMap.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/FeDisplacementMap.java
@@ -76,9 +76,8 @@ public final class FeDisplacementMap extends AbstractFilterPrimitive {
 
     @Override
     public void layoutFilter(@NotNull RenderContext context, @NotNull FilterLayoutContext filterLayoutContext) {
-        LayoutBounds layoutBounds = new LayoutBounds(
-                filterLayoutContext.filterPrimitiveRegion(context.measureContext(), this),
-                new FloatInsets());
+        float grow = Math.abs(scale) / 2f;
+        LayoutBounds layoutBounds = impl().layoutInput(filterLayoutContext).grow(grow, grow, filterLayoutContext);
         impl().saveLayoutResult(layoutBounds, filterLayoutContext);
     }
 

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/FeDisplacementMap.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/FeDisplacementMap.java
@@ -101,7 +101,7 @@ public final class FeDisplacementMap extends AbstractFilterPrimitive {
         }
 
         ImageFilter displacementFilter = new BufferedImageFilter(
-                new DisplacementOp(displacementInput.pixels(context), filterContext.info().tile(),
+                new DisplacementOp(displacementInput.pixels(context), filterContext.info().imageBounds(),
                         displacementScaleX, displacementScaleY));
         impl().saveResult(input.applyFilter(displacementFilter), filterContext);
     }

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/FeDistantLight.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/FeDistantLight.java
@@ -1,0 +1,63 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Jannis Weis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package com.github.weisj.jsvg.nodes.filter;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.github.weisj.jsvg.nodes.AbstractSVGNode;
+import com.github.weisj.jsvg.nodes.prototype.spec.Category;
+import com.github.weisj.jsvg.nodes.prototype.spec.ElementCategories;
+import com.github.weisj.jsvg.nodes.prototype.spec.PermittedContent;
+import com.github.weisj.jsvg.parser.impl.AttributeNode;
+
+@ElementCategories(Category.None)
+@PermittedContent
+public final class FeDistantLight extends AbstractSVGNode implements LightSource {
+    public static final String TAG = "fedistantlight";
+
+    private double x;
+    private double y;
+    private double z;
+
+    @Override
+    public @NotNull String tagName() {
+        return TAG;
+    }
+
+    @Override
+    public void build(@NotNull AttributeNode attributeNode) {
+        super.build(attributeNode);
+
+        double azimuth = Math.toRadians(attributeNode.getFloat("azimuth", 0));
+        double elevation = Math.toRadians(attributeNode.getFloat("elevation", 0));
+        double cosElevation = Math.cos(elevation);
+
+        x = Math.cos(azimuth) * cosElevation;
+        y = Math.sin(azimuth) * cosElevation;
+        z = Math.sin(elevation);
+    }
+
+    @Override
+    public @NotNull Light lightAt(double x, double y, double z) {
+        return new Light(this.x, this.y, this.z, 1);
+    }
+}

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/FeDistantLight.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/FeDistantLight.java
@@ -24,13 +24,17 @@ package com.github.weisj.jsvg.nodes.filter;
 import org.jetbrains.annotations.NotNull;
 
 import com.github.weisj.jsvg.nodes.AbstractSVGNode;
+import com.github.weisj.jsvg.nodes.animation.Animate;
+import com.github.weisj.jsvg.nodes.animation.Set;
 import com.github.weisj.jsvg.nodes.prototype.spec.Category;
 import com.github.weisj.jsvg.nodes.prototype.spec.ElementCategories;
 import com.github.weisj.jsvg.nodes.prototype.spec.PermittedContent;
 import com.github.weisj.jsvg.parser.impl.AttributeNode;
 
 @ElementCategories(Category.LightSource)
-@PermittedContent
+@PermittedContent(
+    anyOf = {Animate.class, Set.class}
+)
 public final class FeDistantLight extends AbstractSVGNode implements LightSource {
     public static final String TAG = "fedistantlight";
 

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/FeDistantLight.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/FeDistantLight.java
@@ -29,7 +29,7 @@ import com.github.weisj.jsvg.nodes.prototype.spec.ElementCategories;
 import com.github.weisj.jsvg.nodes.prototype.spec.PermittedContent;
 import com.github.weisj.jsvg.parser.impl.AttributeNode;
 
-@ElementCategories(Category.None)
+@ElementCategories(Category.LightSource)
 @PermittedContent
 public final class FeDistantLight extends AbstractSVGNode implements LightSource {
     public static final String TAG = "fedistantlight";

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/FePointLight.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/FePointLight.java
@@ -29,7 +29,7 @@ import com.github.weisj.jsvg.nodes.prototype.spec.ElementCategories;
 import com.github.weisj.jsvg.nodes.prototype.spec.PermittedContent;
 import com.github.weisj.jsvg.parser.impl.AttributeNode;
 
-@ElementCategories(Category.None)
+@ElementCategories(Category.LightSource)
 @PermittedContent
 public class FePointLight extends AbstractSVGNode implements LightSource {
     public static final String TAG = "fepointlight";

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/FePointLight.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/FePointLight.java
@@ -24,13 +24,17 @@ package com.github.weisj.jsvg.nodes.filter;
 import org.jetbrains.annotations.NotNull;
 
 import com.github.weisj.jsvg.nodes.AbstractSVGNode;
+import com.github.weisj.jsvg.nodes.animation.Animate;
+import com.github.weisj.jsvg.nodes.animation.Set;
 import com.github.weisj.jsvg.nodes.prototype.spec.Category;
 import com.github.weisj.jsvg.nodes.prototype.spec.ElementCategories;
 import com.github.weisj.jsvg.nodes.prototype.spec.PermittedContent;
 import com.github.weisj.jsvg.parser.impl.AttributeNode;
 
 @ElementCategories(Category.LightSource)
-@PermittedContent
+@PermittedContent(
+    anyOf = {Animate.class, Set.class}
+)
 public class FePointLight extends AbstractSVGNode implements LightSource {
     public static final String TAG = "fepointlight";
 

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/FePointLight.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/FePointLight.java
@@ -1,0 +1,68 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Jannis Weis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package com.github.weisj.jsvg.nodes.filter;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.github.weisj.jsvg.nodes.AbstractSVGNode;
+import com.github.weisj.jsvg.nodes.prototype.spec.Category;
+import com.github.weisj.jsvg.nodes.prototype.spec.ElementCategories;
+import com.github.weisj.jsvg.nodes.prototype.spec.PermittedContent;
+import com.github.weisj.jsvg.parser.impl.AttributeNode;
+
+@ElementCategories(Category.None)
+@PermittedContent
+public class FePointLight extends AbstractSVGNode implements LightSource {
+    public static final String TAG = "fepointlight";
+
+    protected double lightX;
+    protected double lightY;
+    protected double lightZ;
+
+    @Override
+    public @NotNull String tagName() {
+        return TAG;
+    }
+
+    @Override
+    public void build(@NotNull AttributeNode attributeNode) {
+        super.build(attributeNode);
+
+        lightX = attributeNode.getFloat("x", 0);
+        lightY = attributeNode.getFloat("y", 0);
+        lightZ = attributeNode.getFloat("z", 0);
+    }
+
+    @Override
+    public @NotNull Light lightAt(double x, double y, double z) {
+        return computePointLight(x, y, z, 1);
+    }
+
+    protected final @NotNull Light computePointLight(double x, double y, double z, double intensity) {
+        double dx = lightX - x;
+        double dy = lightY - y;
+        double dz = lightZ - z;
+        double length = Math.sqrt(dx * dx + dy * dy + dz * dz);
+        if (length == 0) return new Light(0, 0, 0, 0);
+        return new Light(dx / length, dy / length, dz / length, intensity);
+    }
+}

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/FeSpotLight.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/FeSpotLight.java
@@ -1,0 +1,85 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Jannis Weis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package com.github.weisj.jsvg.nodes.filter;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import com.github.weisj.jsvg.nodes.prototype.spec.Category;
+import com.github.weisj.jsvg.nodes.prototype.spec.ElementCategories;
+import com.github.weisj.jsvg.nodes.prototype.spec.PermittedContent;
+import com.github.weisj.jsvg.parser.impl.AttributeNode;
+
+@ElementCategories(Category.None)
+@PermittedContent
+public final class FeSpotLight extends FePointLight {
+    public static final String TAG = "fespotlight";
+
+    private double directionX;
+    private double directionY;
+    private double directionZ;
+    private double specularExponent;
+    private @Nullable Double limitingConeCos;
+
+    @Override
+    public @NotNull String tagName() {
+        return TAG;
+    }
+
+    @Override
+    public void build(@NotNull AttributeNode attributeNode) {
+        super.build(attributeNode);
+
+        double pointsAtX = attributeNode.getFloat("pointsAtX", 0);
+        double pointsAtY = attributeNode.getFloat("pointsAtY", 0);
+        double pointsAtZ = attributeNode.getFloat("pointsAtZ", 0);
+        double dx = pointsAtX - lightX;
+        double dy = pointsAtY - lightY;
+        double dz = pointsAtZ - lightZ;
+        double length = Math.sqrt(dx * dx + dy * dy + dz * dz);
+        if (length != 0) {
+            directionX = dx / length;
+            directionY = dy / length;
+            directionZ = dz / length;
+        }
+
+        specularExponent = attributeNode.getNonNegativeFloat("specularExponent", 1);
+        String limitingConeAngle = attributeNode.getValue("limitingConeAngle");
+        if (limitingConeAngle != null) {
+            limitingConeCos = Math.cos(Math.toRadians(attributeNode.getFloat("limitingConeAngle", 0)));
+        } else {
+            limitingConeCos = null;
+        }
+    }
+
+    @Override
+    public @NotNull Light lightAt(double x, double y, double z) {
+        Light light = computePointLight(x, y, z, 1);
+        if (light.intensity == 0) return light;
+
+        double dot = -(light.x * directionX + light.y * directionY + light.z * directionZ);
+        if (dot <= 0) return new Light(light.x, light.y, light.z, 0);
+        if (limitingConeCos != null && dot < limitingConeCos) return new Light(light.x, light.y, light.z, 0);
+
+        return new Light(light.x, light.y, light.z, Math.pow(dot, specularExponent));
+    }
+}

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/FeSpotLight.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/FeSpotLight.java
@@ -29,7 +29,7 @@ import com.github.weisj.jsvg.nodes.prototype.spec.ElementCategories;
 import com.github.weisj.jsvg.nodes.prototype.spec.PermittedContent;
 import com.github.weisj.jsvg.parser.impl.AttributeNode;
 
-@ElementCategories(Category.None)
+@ElementCategories(Category.LightSource)
 @PermittedContent
 public final class FeSpotLight extends FePointLight {
     public static final String TAG = "fespotlight";

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/FeSpotLight.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/FeSpotLight.java
@@ -24,13 +24,17 @@ package com.github.weisj.jsvg.nodes.filter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import com.github.weisj.jsvg.nodes.animation.Animate;
+import com.github.weisj.jsvg.nodes.animation.Set;
 import com.github.weisj.jsvg.nodes.prototype.spec.Category;
 import com.github.weisj.jsvg.nodes.prototype.spec.ElementCategories;
 import com.github.weisj.jsvg.nodes.prototype.spec.PermittedContent;
 import com.github.weisj.jsvg.parser.impl.AttributeNode;
 
 @ElementCategories(Category.LightSource)
-@PermittedContent
+@PermittedContent(
+    anyOf = {Animate.class, Set.class}
+)
 public final class FeSpotLight extends FePointLight {
     public static final String TAG = "fespotlight";
 

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/LightSource.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/LightSource.java
@@ -1,0 +1,46 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Jannis Weis
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package com.github.weisj.jsvg.nodes.filter;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.github.weisj.jsvg.nodes.SVGNode;
+
+interface LightSource extends SVGNode {
+
+    @NotNull
+    Light lightAt(double x, double y, double z);
+
+    final class Light {
+        final double x;
+        final double y;
+        final double z;
+        final double intensity;
+
+        Light(double x, double y, double z, double intensity) {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+            this.intensity = intensity;
+        }
+    }
+}

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/LightSource.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/filter/LightSource.java
@@ -23,9 +23,7 @@ package com.github.weisj.jsvg.nodes.filter;
 
 import org.jetbrains.annotations.NotNull;
 
-import com.github.weisj.jsvg.nodes.SVGNode;
-
-interface LightSource extends SVGNode {
+interface LightSource {
 
     @NotNull
     Light lightAt(double x, double y, double z);

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/prototype/spec/Category.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/prototype/spec/Category.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2021-2024 Jannis Weis
+ * Copyright (c) 2021-2026 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,

--- a/jsvg/src/main/java/com/github/weisj/jsvg/nodes/prototype/spec/Category.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/nodes/prototype/spec/Category.java
@@ -34,6 +34,7 @@ public enum Category {
     // in a static context.
     Descriptive(false),
     FilterPrimitive,
+    LightSource,
     TransferFunctionElement,
     Gradient,
     Graphic,

--- a/jsvg/src/main/java/com/github/weisj/jsvg/parser/impl/NodeSupplier.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/parser/impl/NodeSupplier.java
@@ -114,7 +114,9 @@ public final class NodeSupplier {
         constructorMap.put(FeBlend.TAG, () -> new FeBlend());
         constructorMap.put(FeColorMatrix.TAG, () -> new FeColorMatrix());
         constructorMap.put(FeComposite.TAG, () -> new FeComposite());
+        constructorMap.put(FeDiffuseLighting.TAG, () -> new FeDiffuseLighting());
         constructorMap.put(FeDisplacementMap.TAG, () -> new FeDisplacementMap());
+        constructorMap.put(FeDistantLight.TAG, () -> new FeDistantLight());
         constructorMap.put(FeDropShadow.TAG, () -> new FeDropShadow());
         constructorMap.put(FeFlood.TAG, () -> new FeFlood());
         constructorMap.put(FeGaussianBlur.TAG, () -> new FeGaussianBlur());
@@ -122,6 +124,8 @@ public final class NodeSupplier {
         constructorMap.put(FeMergeNode.TAG, () -> new FeMergeNode());
         constructorMap.put(FeTurbulence.TAG, () -> new FeTurbulence());
         constructorMap.put(FeOffset.TAG, () -> new FeOffset());
+        constructorMap.put(FePointLight.TAG, () -> new FePointLight());
+        constructorMap.put(FeSpotLight.TAG, () -> new FeSpotLight());
         constructorMap.put(FeComponentTransfer.TAG, () -> new FeComponentTransfer());
         constructorMap.put(TransferFunctionElement.FeFuncB.TAG, () -> new TransferFunctionElement.FeFuncB());
         constructorMap.put(TransferFunctionElement.FeFuncG.TAG, () -> new TransferFunctionElement.FeFuncG());
@@ -143,7 +147,6 @@ public final class NodeSupplier {
 
     private void populateDummyNodeConstructors() {
         constructorMap.put("feConvolveMatrix", () -> new DummyFilterPrimitive("feConvolveMatrix"));
-        constructorMap.put("feDiffuseLighting", () -> new DummyFilterPrimitive("feDiffuseLighting"));
         constructorMap.put("feImage", () -> new DummyFilterPrimitive("feImage"));
         constructorMap.put("feMorphology", () -> new DummyFilterPrimitive("feMorphology"));
         constructorMap.put("feSpecularLighting", () -> new DummyFilterPrimitive("feSpecularLighting"));

--- a/jsvg/src/main/java/com/github/weisj/jsvg/parser/impl/NodeSupplier.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/parser/impl/NodeSupplier.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023-2025 Jannis Weis
+ * Copyright (c) 2023-2026 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,

--- a/jsvg/src/test/java/com/github/weisj/jsvg/FilterTest.java
+++ b/jsvg/src/test/java/com/github/weisj/jsvg/FilterTest.java
@@ -116,6 +116,7 @@ class FilterTest {
     @Test
     void testDisplacementMap() {
         assertEquals(SUCCESS, compareImages("filter/displacement.svg"));
+        assertEquals(SUCCESS, compareImages("filter/displacementNegativeCoordinates.svg", 0.4));
     }
 
     @Test

--- a/jsvg/src/test/java/com/github/weisj/jsvg/FilterTest.java
+++ b/jsvg/src/test/java/com/github/weisj/jsvg/FilterTest.java
@@ -121,6 +121,7 @@ class FilterTest {
     @Test
     void testDiffuseLighting() {
         assertEquals(SUCCESS, compareImages("filter/diffuseLighting.svg", 0.2, 0.15));
+        assertEquals(SUCCESS, compareImages("filter/diffuseLighting_issue167.svg", 0.2, 0.15));
     }
 
     @Test

--- a/jsvg/src/test/java/com/github/weisj/jsvg/FilterTest.java
+++ b/jsvg/src/test/java/com/github/weisj/jsvg/FilterTest.java
@@ -119,6 +119,11 @@ class FilterTest {
     }
 
     @Test
+    void testDiffuseLighting() {
+        assertEquals(SUCCESS, compareImages("filter/diffuseLighting.svg", 0.2, 0.15));
+    }
+
+    @Test
     void testComposite() {
         // TODO: BackgroundImage not supported
         assertDoesNotThrow(() -> renderJsvg("filter/composite.svg"));

--- a/jsvg/src/test/resources/com/github/weisj/jsvg/filter/diffuseLighting.svg
+++ b/jsvg/src/test/resources/com/github/weisj/jsvg/filter/diffuseLighting.svg
@@ -1,26 +1,33 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1286" height="500" viewBox="0 0 180 70">
-    <defs>
-        <filter id="distant" x="0" y="0" width="1" height="1">
-            <feDiffuseLighting in="SourceGraphic" lighting-color="#ffcc66" surfaceScale="6" diffuseConstant="1.1">
-                <feDistantLight azimuth="45" elevation="35"/>
-            </feDiffuseLighting>
-            <feComposite in2="SourceGraphic" operator="in"/>
-        </filter>
-        <filter id="point" x="0" y="0" width="1" height="1">
-            <feDiffuseLighting in="SourceGraphic" lighting-color="#99ddff" surfaceScale="4" diffuseConstant="1.2">
-                <fePointLight x="86" y="15" z="36"/>
-            </feDiffuseLighting>
-            <feComposite in2="SourceGraphic" operator="in"/>
-        </filter>
-        <filter id="spot" x="0" y="0" width="1" height="1">
-            <feDiffuseLighting in="SourceGraphic" lighting-color="#d8ff9a" surfaceScale="5" diffuseConstant="1.3">
-                <feSpotLight x="142" y="-12" z="42" pointsAtX="144" pointsAtY="36" pointsAtZ="0"
-                    specularExponent="3" limitingConeAngle="30"/>
-            </feDiffuseLighting>
-            <feComposite in2="SourceGraphic" operator="in"/>
-        </filter>
-    </defs>
-    <rect x="12" y="14" width="42" height="42" rx="10" fill="black" filter="url(#distant)"/>
-    <circle cx="90" cy="35" r="22" fill="black" filter="url(#point)"/>
-    <path d="M126 56 L146 12 L168 56 Z" fill="black" filter="url(#spot)"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="1286" height="500"
+	viewBox="0 0 180 70">
+	<defs>
+		<filter id="distant" x="0" y="0" width="1" height="1">
+			<feDiffuseLighting in="SourceGraphic"
+				lighting-color="#ffcc66" surfaceScale="6" diffuseConstant="1.1">
+				<feDistantLight azimuth="45" elevation="35" />
+			</feDiffuseLighting>
+			<feComposite in2="SourceGraphic" operator="in" />
+		</filter>
+		<filter id="point" x="0" y="0" width="1" height="1">
+			<feDiffuseLighting in="SourceGraphic"
+				lighting-color="#99ddff" surfaceScale="4" diffuseConstant="1.2">
+				<fePointLight x="86" y="15" z="36" />
+			</feDiffuseLighting>
+			<feComposite in2="SourceGraphic" operator="in" />
+		</filter>
+		<filter id="spot" x="0" y="0" width="1" height="1">
+			<feDiffuseLighting in="SourceGraphic"
+				lighting-color="#d8ff9a" surfaceScale="5" diffuseConstant="1.3">
+				<feSpotLight x="142" y="-12" z="42" pointsAtX="144"
+					pointsAtY="36" pointsAtZ="0" specularExponent="3"
+					limitingConeAngle="30" />
+			</feDiffuseLighting>
+			<feComposite in2="SourceGraphic" operator="in" />
+		</filter>
+	</defs>
+	<rect x="12" y="14" width="42" height="42" rx="10" fill="black"
+		filter="url(#distant)" />
+	<circle cx="90" cy="35" r="22" fill="black" filter="url(#point)" />
+	<path d="M126 56 L146 12 L168 56 Z" fill="black"
+		filter="url(#spot)" />
 </svg>

--- a/jsvg/src/test/resources/com/github/weisj/jsvg/filter/diffuseLighting.svg
+++ b/jsvg/src/test/resources/com/github/weisj/jsvg/filter/diffuseLighting.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="180" height="70" viewBox="0 0 180 70">
+<svg xmlns="http://www.w3.org/2000/svg" width="1286" height="500" viewBox="0 0 180 70">
     <defs>
         <filter id="distant" x="0" y="0" width="1" height="1">
             <feDiffuseLighting in="SourceGraphic" lighting-color="#ffcc66" surfaceScale="6" diffuseConstant="1.1">

--- a/jsvg/src/test/resources/com/github/weisj/jsvg/filter/diffuseLighting.svg
+++ b/jsvg/src/test/resources/com/github/weisj/jsvg/filter/diffuseLighting.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="180" height="70" viewBox="0 0 180 70">
+    <defs>
+        <filter id="distant" x="0" y="0" width="1" height="1">
+            <feDiffuseLighting in="SourceGraphic" lighting-color="#ffcc66" surfaceScale="6" diffuseConstant="1.1">
+                <feDistantLight azimuth="45" elevation="35"/>
+            </feDiffuseLighting>
+            <feComposite in2="SourceGraphic" operator="in"/>
+        </filter>
+        <filter id="point" x="0" y="0" width="1" height="1">
+            <feDiffuseLighting in="SourceGraphic" lighting-color="#99ddff" surfaceScale="4" diffuseConstant="1.2">
+                <fePointLight x="86" y="15" z="36"/>
+            </feDiffuseLighting>
+            <feComposite in2="SourceGraphic" operator="in"/>
+        </filter>
+        <filter id="spot" x="0" y="0" width="1" height="1">
+            <feDiffuseLighting in="SourceGraphic" lighting-color="#d8ff9a" surfaceScale="5" diffuseConstant="1.3">
+                <feSpotLight x="142" y="-12" z="42" pointsAtX="144" pointsAtY="36" pointsAtZ="0"
+                    specularExponent="3" limitingConeAngle="30"/>
+            </feDiffuseLighting>
+            <feComposite in2="SourceGraphic" operator="in"/>
+        </filter>
+    </defs>
+    <rect x="12" y="14" width="42" height="42" rx="10" fill="black" filter="url(#distant)"/>
+    <circle cx="90" cy="35" r="22" fill="black" filter="url(#point)"/>
+    <path d="M126 56 L146 12 L168 56 Z" fill="black" filter="url(#spot)"/>
+</svg>

--- a/jsvg/src/test/resources/com/github/weisj/jsvg/filter/diffuseLighting_issue167.svg
+++ b/jsvg/src/test/resources/com/github/weisj/jsvg/filter/diffuseLighting_issue167.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+     viewBox="0 0 260 140"
+     width="260"
+     height="140">
+  <defs>
+    <filter id="paper">
+      <feTurbulence
+        type="fractalNoise"
+        baseFrequency="0.04"
+        result="noise"
+        numOctaves="5"/>
+
+      <feDiffuseLighting in="noise" surfaceScale="2" result="texture">
+        <feDistantLight azimuth="45" elevation="75"/>
+      </feDiffuseLighting>
+
+      <feComposite
+        in="SourceGraphic"
+        in2="texture"
+        operator="arithmetic"
+        k1="1"
+        k2="0"
+        k3="0"
+        k4="0"/>
+    </filter>
+  </defs>
+
+  <rect x="10" y="10" width="110" height="110"
+        fill="rgb(200,230,150)"
+        stroke="#444444"
+        filter="url(#paper)"/>
+
+  <rect x="140" y="10" width="110" height="110"
+        fill="rgb(200,230,150)"
+        stroke="#444444"/>
+</svg>

--- a/jsvg/src/test/resources/com/github/weisj/jsvg/filter/diffuseLighting_issue167.svg
+++ b/jsvg/src/test/resources/com/github/weisj/jsvg/filter/diffuseLighting_issue167.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      viewBox="0 0 260 140"
-     width="260"
-     height="140">
+     width="929"
+     height="500">
   <defs>
     <filter id="paper">
       <feTurbulence

--- a/jsvg/src/test/resources/com/github/weisj/jsvg/filter/diffuseLighting_issue167.svg
+++ b/jsvg/src/test/resources/com/github/weisj/jsvg/filter/diffuseLighting_issue167.svg
@@ -1,36 +1,23 @@
-<svg xmlns="http://www.w3.org/2000/svg"
-     viewBox="0 0 260 140"
-     width="929"
-     height="500">
-  <defs>
-    <filter id="paper">
-      <feTurbulence
-        type="fractalNoise"
-        baseFrequency="0.04"
-        result="noise"
-        numOctaves="5"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 260 140"
+	width="929" height="500">
+	<defs>
+		<filter id="paper">
+			<feTurbulence type="fractalNoise" baseFrequency="0.04"
+				result="noise" numOctaves="5" />
 
-      <feDiffuseLighting in="noise" surfaceScale="2" result="texture">
-        <feDistantLight azimuth="45" elevation="75"/>
-      </feDiffuseLighting>
+			<feDiffuseLighting in="noise" surfaceScale="2"
+				result="texture">
+				<feDistantLight azimuth="45" elevation="75" />
+			</feDiffuseLighting>
 
-      <feComposite
-        in="SourceGraphic"
-        in2="texture"
-        operator="arithmetic"
-        k1="1"
-        k2="0"
-        k3="0"
-        k4="0"/>
-    </filter>
-  </defs>
+			<feComposite in="SourceGraphic" in2="texture"
+				operator="arithmetic" k1="1" k2="0" k3="0" k4="0" />
+		</filter>
+	</defs>
 
-  <rect x="10" y="10" width="110" height="110"
-        fill="rgb(200,230,150)"
-        stroke="#444444"
-        filter="url(#paper)"/>
+	<rect x="10" y="10" width="110" height="110"
+		fill="rgb(200,230,150)" stroke="#444444" filter="url(#paper)" />
 
-  <rect x="140" y="10" width="110" height="110"
-        fill="rgb(200,230,150)"
-        stroke="#444444"/>
+	<rect x="140" y="10" width="110" height="110"
+		fill="rgb(200,230,150)" stroke="#444444" />
 </svg>

--- a/jsvg/src/test/resources/com/github/weisj/jsvg/filter/displacementNegativeCoordinates.svg
+++ b/jsvg/src/test/resources/com/github/weisj/jsvg/filter/displacementNegativeCoordinates.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 260 180" width="260" height="180">
+  <defs>
+    <filter id="stream">
+      <feTurbulence
+        type="fractalNoise"
+        baseFrequency="0.05"
+        numOctaves="3"
+        result="noise"/>
+      <feDisplacementMap
+        in2="noise"
+        in="SourceGraphic"
+        scale="10"
+        xChannelSelector="R"
+        yChannelSelector="G"/>
+    </filter>
+  </defs>
+
+  <rect x="0" y="0" width="260" height="180" fill="white"/>
+  <g fill="none" stroke="blue" stroke-width="18" stroke-linecap="round" stroke-opacity="0.6"
+      stroke-linejoin="round">
+    <g transform="translate(20,150)" filter="url(#stream)">
+      <polyline
+        points="
+          20, 20
+          60, 0
+          60, -40
+          100, -60
+          100, -100
+          140, -120
+          180, -100
+          220, -120
+        "/>
+    </g>
+  </g>
+</svg>

--- a/jsvg/src/test/resources/com/github/weisj/jsvg/filter/displacementNegativeCoordinates.svg
+++ b/jsvg/src/test/resources/com/github/weisj/jsvg/filter/displacementNegativeCoordinates.svg
@@ -1,26 +1,20 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 260 180" width="260" height="180">
-  <defs>
-    <filter id="stream">
-      <feTurbulence
-        type="fractalNoise"
-        baseFrequency="0.05"
-        numOctaves="3"
-        result="noise"/>
-      <feDisplacementMap
-        in2="noise"
-        in="SourceGraphic"
-        scale="10"
-        xChannelSelector="R"
-        yChannelSelector="G"/>
-    </filter>
-  </defs>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 260 180"
+	width="260" height="180">
+	<defs>
+		<filter id="stream">
+			<feTurbulence type="fractalNoise" baseFrequency="0.05"
+				numOctaves="3" result="noise" />
+			<feDisplacementMap in2="noise" in="SourceGraphic"
+				scale="10" xChannelSelector="R" yChannelSelector="G" />
+		</filter>
+	</defs>
 
-  <rect x="0" y="0" width="260" height="180" fill="white"/>
-  <g fill="none" stroke="blue" stroke-width="18" stroke-linecap="round" stroke-opacity="0.6"
-      stroke-linejoin="round">
-    <g transform="translate(20,150)" filter="url(#stream)">
-      <polyline
-        points="
+	<rect x="0" y="0" width="260" height="180" fill="white" />
+	<g fill="none" stroke="blue" stroke-width="18" stroke-linecap="round"
+		stroke-opacity="0.6" stroke-linejoin="round">
+		<g transform="translate(20,150)" filter="url(#stream)">
+			<polyline
+				points="
           20, 20
           60, 0
           60, -40
@@ -29,7 +23,7 @@
           140, -120
           180, -100
           220, -120
-        "/>
-    </g>
-  </g>
+        " />
+		</g>
+	</g>
 </svg>


### PR DESCRIPTION
# Implement feDiffuseLighting and fix related filter rendering

Fixes #167

The big, custom game map in question I used for spot testing [here](https://github.com/djberg96/Hastings-1066/blob/main/Images/Misc/hex_map.svg).

## Summary

This adds real support for `feDiffuseLighting`, including `feDistantLight`, `fePointLight`, and `feSpotLight`.

While testing the reduced SVG from #167 and a larger map that uses the same kind of filtered texture work, two follow-up filter bugs showed up as well. This PR fixes those too:

- `feComposite operator="arithmetic"` now handles fractional coefficients correctly and applies the SVG arithmetic formula using normalized color channels.
- `feDisplacementMap` now lays out its filter region from the displaced input bounds, so paths with negative local coordinates do not get clipped before displacement is applied.

The result is that the reduced example from #167 renders as the intended diffuse-lit texture instead of failing on the missing `texture` input, and larger SVGs using turbulence plus displacement keep their filtered paths intact.

## What changed

- Added `FeDiffuseLighting` and light-source node support:
  - `feDistantLight`
  - `fePointLight`
  - `feSpotLight`
- Registered the new filter nodes with the parser.
- Updated the README filter support table.
- Fixed arithmetic compositing for decimal `k1`/`k2`/`k3`/`k4` values.
- Fixed displacement-map filter bounds for displaced content extending outside the primitive's default layout.
- Added regression SVG fixtures for:
  - basic diffuse lighting
  - the reduced #167 diffuse-lighting/turbulence/composite case
  - displacement of content with negative local coordinates

## Verification

- Rendered the reduced SVG from #167 and confirmed it produces the expected green diffuse-lit texture.
- Rendered the full Hastings hex map locally and confirmed the previously missing stream segments render, with turbulence/displacement still visible.
- Ran a direct `javac` compile/smoke path for the changed JSVG sources.

I was not able to run the full Gradle test suite in this local environment because the installed JDK reports itself as `26.0.1`, which trips the current Gradle/Kotlin version parsing before tests start. The new regression fixtures are wired into `FilterTest` for normal CI/test environments.

Sorry, I'm not familiar with Gradle, so if there's something else I can do locally please let me know. Locally I'm running on Mac Tahoe 26.5.1 with openjdk version "26.0.1" 2026-04-21 via homebrew.
