### PR TITLE
Custom font support

### DIFF
--- a/jsvg/src/main/java/com/github/weisj/jsvg/attributes/font/FontResolver.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/attributes/font/FontResolver.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2021-2025 Jannis Weis
+ * Copyright (c) 2021-2026 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -21,16 +21,22 @@
  */
 package com.github.weisj.jsvg.attributes.font;
 
-import java.awt.*;
+import java.awt.Font;
+import java.awt.GraphicsEnvironment;
 import java.awt.font.TextAttribute;
 import java.awt.geom.AffineTransform;
 import java.text.AttributedCharacterIterator;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 import org.jetbrains.annotations.NotNull;
 
 import com.github.weisj.jsvg.renderer.MeasureContext;
+import com.github.weisj.jsvg.renderer.PlatformSupport;
 
 public final class FontResolver {
     private FontResolver() {}
@@ -40,19 +46,14 @@ public final class FontResolver {
     }
 
     public static @NotNull SVGFont resolve(@NotNull MeasurableFontSpec fontSpec,
-            @NotNull MeasureContext measureContext, @NotNull String defaultFontFamily) {
+            @NotNull MeasureContext measureContext, @NotNull PlatformSupport platformSupport) {
         FontCache.CacheKey key = new FontCache.CacheKey(fontSpec, measureContext);
-        SVGFont cachedFont = FontCache.INSTANCE.cache.get(key);
-        if (cachedFont != null) return cachedFont;
-        SVGFont resolvedFont = resolveWithoutCache(fontSpec, measureContext, defaultFontFamily);
-        FontCache.INSTANCE.cache.put(key, resolvedFont);
-        return resolvedFont;
+        return FontCache.INSTANCE.cache.computeIfAbsent(key,
+                k -> resolveWithoutCache(fontSpec, measureContext, platformSupport));
     }
 
     public static @NotNull SVGFont resolveWithoutCache(@NotNull MeasurableFontSpec fontSpec,
-            @NotNull MeasureContext measureContext, @NotNull String defaultFontFamily) {
-        String family = findSupportedFontFamily(fontSpec, defaultFontFamily);
-
+            @NotNull MeasureContext measureContext, @NotNull PlatformSupport platformSupport) {
         FontStyle style = fontSpec.style();
 
         float weight = cssWeightToAwtWeight(fontSpec.currentWeight());
@@ -60,11 +61,9 @@ public final class FontResolver {
         float stretch = fontSpec.stretch().orElseIfUnspecified(1).value();
 
         Map<AttributedCharacterIterator.Attribute, Object> attributes = new HashMap<>(5, 1f);
-        attributes.put(TextAttribute.FAMILY, family);
         attributes.put(TextAttribute.SIZE, size);
         attributes.put(TextAttribute.WEIGHT, weight);
         attributes.put(TextAttribute.WIDTH, stretch);
-
 
         if (style instanceof FontStyle.Normal) {
             attributes.put(TextAttribute.POSTURE, TextAttribute.POSTURE_REGULAR);
@@ -75,8 +74,30 @@ public final class FontResolver {
             if (transform != null) attributes.put(TextAttribute.TRANSFORM, transform);
         }
 
-        Font font = new Font(attributes);
+        Font font = resolveFont(fontSpec, platformSupport, attributes);
         return new AWTSVGFont(font);
+    }
+
+    /** Resolves and sets the first matching font family based on {@code fontSpec.families}. */
+    private static @NotNull Font resolveFont(@NotNull MeasurableFontSpec fontSpec,
+            @NotNull PlatformSupport platformSupport,
+            @NotNull Map<AttributedCharacterIterator.Attribute, Object> attributes) {
+        for (String family : fontSpec.families()) {
+            // Prefer predefined fonts, then custom fonts supplied by the platform.
+            if (FontFamiliesCache.INSTANCE.isSupportedFontFamily(family)) {
+                attributes.put(TextAttribute.FAMILY, family);
+                return new Font(attributes);
+            }
+            // If no predefined font was found, try to find a custom font.
+            Font customFont = platformSupport.customFont(family);
+            if (customFont != null) {
+                attributes.put(TextAttribute.FAMILY, family);
+                return customFont.deriveFont(attributes);
+            }
+        }
+        // return default font if nothing was matched
+        attributes.put(TextAttribute.FAMILY, platformSupport.fontFamily());
+        return new Font(attributes);
     }
 
     private static float cssWeightToAwtWeight(float weight) {
@@ -91,15 +112,6 @@ public final class FontResolver {
             currentWeight *= awtWeightCompensationFactor;
         }
         return currentWeight / normalWeight;
-    }
-
-    private static @NotNull String findSupportedFontFamily(@NotNull MeasurableFontSpec fontSpec,
-            @NotNull String defaultFontFamily) {
-        String[] families = fontSpec.families();
-        for (String family : families) {
-            if (FontFamiliesCache.INSTANCE.isSupportedFontFamily(family)) return family;
-        }
-        return defaultFontFamily;
     }
 
     public static @NotNull List<@NotNull String> supportedFonts() {

--- a/jsvg/src/main/java/com/github/weisj/jsvg/attributes/font/FontResolver.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/attributes/font/FontResolver.java
@@ -91,7 +91,8 @@ public final class FontResolver {
             // If no predefined font was found, try to find a custom font.
             Font customFont = platformSupport.customFont(family);
             if (customFont != null) {
-                attributes.put(TextAttribute.FAMILY, family);
+                // No FAMILY attribute: deriveFont discards the created font handle if it doesn't
+                // match the font's name exactly and falls back to a system font lookup.
                 return customFont.deriveFont(attributes);
             }
         }

--- a/jsvg/src/main/java/com/github/weisj/jsvg/renderer/PlatformSupport.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/renderer/PlatformSupport.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2023-2025 Jannis Weis
+ * Copyright (c) 2023-2026 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -48,6 +48,12 @@ public interface PlatformSupport {
 
     default @NotNull String fontFamily() {
         return SVGFont.defaultFontFamily();
+    }
+
+    // Custom font for a family not registered with the platform, or null if none is provided.
+    // The family is CSS-canonicalized (lower-cased); implementations must match accordingly.
+    default @Nullable Font customFont(@NotNull String family) {
+        return null;
     }
 
     default @NotNull Image createImage(@NotNull ImageProducer imageProducer) {

--- a/jsvg/src/main/java/com/github/weisj/jsvg/renderer/PlatformSupport.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/renderer/PlatformSupport.java
@@ -25,6 +25,7 @@ import java.awt.*;
 import java.awt.image.ImageObserver;
 import java.awt.image.ImageProducer;
 
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -50,8 +51,9 @@ public interface PlatformSupport {
         return SVGFont.defaultFontFamily();
     }
 
-    // Custom font for a family not registered with the platform, or null if none is provided.
-    // The family is CSS-canonicalized (lower-cased); implementations must match accordingly.
+    /** Custom font for a family not registered with the platform, or null if none is provided.
+     * The family is CSS-canonicalized (lower-cased); implementations must match accordingly. */
+    @ApiStatus.Experimental
     default @Nullable Font customFont(@NotNull String family) {
         return null;
     }

--- a/jsvg/src/main/java/com/github/weisj/jsvg/renderer/RenderContext.java
+++ b/jsvg/src/main/java/com/github/weisj/jsvg/renderer/RenderContext.java
@@ -370,7 +370,7 @@ public final class RenderContext {
     }
 
     private @NotNull SVGFont font() {
-        return FontResolver.resolve(this.fontSpec, this.measureContext, platformSupport.fontFamily());
+        return FontResolver.resolve(this.fontSpec, this.measureContext, platformSupport);
     }
 
     private void setRootTransform(@NotNull AffineTransform rootTransform) {

--- a/jsvg/src/test/java/com/github/weisj/jsvg/ReSvgTestSuite.java
+++ b/jsvg/src/test/java/com/github/weisj/jsvg/ReSvgTestSuite.java
@@ -28,25 +28,37 @@ import static com.github.weisj.jsvg.ImageComparison.ReferenceTestResult.SUCCESS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import java.awt.Font;
+import java.awt.FontFormatException;
+import java.awt.image.ImageObserver;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.function.Executable;
 
 import com.github.weisj.jsvg.ImageComparison.RenderType;
+import com.github.weisj.jsvg.attributes.font.FontResolver;
+import com.github.weisj.jsvg.renderer.PlatformSupport;
 
 class ReSvgTestSuite {
 
     private static final Logger LOGGER = Logging.getLogger(ReSvgTestSuite.class);
     private static final String RESVG_TEST_SUITE_PATH = System.getenv("RESVG_TEST_SUITE_PATH");
+
+    // JSVG render type carrying the fonts bundled with the suite (set up in @BeforeAll).
+    private static @NotNull RenderType jsvgRenderType = RenderType.JSVG;
 
     static Collection<DynamicTest> checkDirectory(@NotNull String name) {
         return checkDirectory(name, Collections.emptySet());
@@ -71,7 +83,7 @@ class ReSvgTestSuite {
     }
 
     @BeforeAll
-    static void checkForReSVGRepository() {
+    static void checkForReSVGRepositoryAndRegisterFonts() {
         var exists = Path.of(RESVG_TEST_SUITE_PATH).toFile().exists();
         var message = """
                 The resvg submodule was not found. Skipping ReSVG test suite.
@@ -81,6 +93,50 @@ class ReSvgTestSuite {
             LOGGER.warn(message);
         }
         assumeTrue(exists, message);
+
+        jsvgRenderType = new RenderType.JSVGType(RenderType.JSVG.loaderContext(), loadBundledFonts());
+        // Drop any fallback fonts a prior test cached for these families in the shared JVM.
+        FontResolver.clearFontCache();
+    }
+
+    private static @NotNull PlatformSupport loadBundledFonts() {
+        Map<String, Font> fonts = new HashMap<>();
+        Path fontDir = Path.of(RESVG_TEST_SUITE_PATH).getParent().resolve("fonts");
+        try (var files = Files.walk(fontDir)) {
+            files.filter(p -> p.toString().endsWith(".ttf")).forEach(p -> {
+                try {
+                    Font font = Font.createFont(Font.TRUETYPE_FONT, p.toFile());
+                    // FontResolver looks up the CSS-canonicalized (lower-cased) family name.
+                    String family = font.getFamily().toLowerCase(Locale.US);
+                    // A family may span multiple files; prefer the regular variant.
+                    if (p.getFileName().toString().contains("Regular") || !fonts.containsKey(family)) {
+                        fonts.put(family, font);
+                    }
+                } catch (IOException | FontFormatException e) {
+                    LOGGER.warn("Failed to load font " + p, e);
+                }
+            });
+        } catch (IOException e) {
+            LOGGER.warn("Failed to walk font directory " + fontDir, e);
+        }
+        return new BundledFontSupport(fonts);
+    }
+
+    private record BundledFontSupport(@NotNull Map<String, Font> fonts) implements PlatformSupport {
+        @Override
+        public @Nullable ImageObserver imageObserver() {
+            return null;
+        }
+
+        @Override
+        public @Nullable TargetSurface targetSurface() {
+            return null;
+        }
+
+        @Override
+        public @Nullable Font customFont(@NotNull String family) {
+            return fonts.get(family.toLowerCase(Locale.US));
+        }
     }
 
     @TestFactory
@@ -186,7 +242,7 @@ class ReSvgTestSuite {
                     expected(new UrlImageSource(pngRef.toUri().toURL()),
                             RenderType.DiskImage),
                     actual(new UrlImageSource(testFile.toUri().toURL()),
-                            RenderType.JSVG)));
+                            jsvgRenderType)));
             assertEquals(SUCCESS, result);
         }
     }

--- a/jsvg/src/test/java/com/github/weisj/jsvg/attribute/FontTest.java
+++ b/jsvg/src/test/java/com/github/weisj/jsvg/attribute/FontTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2022-2025 Jannis Weis
+ * Copyright (c) 2022-2026 Jannis Weis
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -21,6 +21,8 @@
  */
 package com.github.weisj.jsvg.attribute;
 
+import java.awt.Font;
+import java.awt.image.ImageObserver;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -30,9 +32,14 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import com.github.weisj.jsvg.attributes.font.*;
+import com.github.weisj.jsvg.attributes.font.FontParser;
+import com.github.weisj.jsvg.attributes.font.FontResolver;
+import com.github.weisj.jsvg.attributes.font.MeasurableFontSpec;
+import com.github.weisj.jsvg.attributes.font.SVGFont;
 import com.github.weisj.jsvg.parser.impl.ParserTestUtil;
 import com.github.weisj.jsvg.renderer.MeasureContext;
+import com.github.weisj.jsvg.renderer.NullPlatformSupport;
+import com.github.weisj.jsvg.renderer.PlatformSupport;
 import com.github.weisj.jsvg.renderer.animation.AnimationState;
 import com.github.weisj.jsvg.view.FloatSize;
 
@@ -53,8 +60,8 @@ class FontTest {
         Supplier<MeasurableFontSpec> fontSpec = () -> createFontSpec(
                 entry("font-family", "sans-serif"),
                 entry("font-size", "11"));
-        SVGFont font1 = FontResolver.resolve(fontSpec.get(), MEASURE_CONTEXT, SVGFont.defaultFontFamily());
-        SVGFont font2 = FontResolver.resolve(fontSpec.get(), MEASURE_CONTEXT, SVGFont.defaultFontFamily());
+        SVGFont font1 = FontResolver.resolve(fontSpec.get(), MEASURE_CONTEXT, NullPlatformSupport.INSTANCE);
+        SVGFont font2 = FontResolver.resolve(fontSpec.get(), MEASURE_CONTEXT, NullPlatformSupport.INSTANCE);
         Assertions.assertSame(font1, font2);
     }
 
@@ -64,9 +71,47 @@ class FontTest {
         MeasurableFontSpec fontSpec = createFontSpec(
                 entry("font-family", fontName),
                 entry("font-size", "3em"));
-        SVGFont font = FontResolver.resolveWithoutCache(fontSpec, MEASURE_CONTEXT, SVGFont.defaultFontFamily());
+        SVGFont font = FontResolver.resolveWithoutCache(fontSpec, MEASURE_CONTEXT, NullPlatformSupport.INSTANCE);
         Assertions.assertEquals(fontName, font.family());
         Assertions.assertEquals(3 * MEASURE_CONTEXT.em(), font.size());
+    }
+
+    String queriedFontFamily;
+
+    @Test
+    void customFontIsUsed() {
+        PlatformSupport support = getSupport();
+
+        // "NoSuchFamily" is not a registered AWT family, so the custom hook must be used.
+        MeasurableFontSpec fontSpec = createFontSpec(
+                entry("font-family", "NoSuchFamily"),
+                entry("font-size", "12"));
+        SVGFont font = FontResolver.resolveWithoutCache(fontSpec, MEASURE_CONTEXT, support);
+
+        Assertions.assertEquals("nosuchfamily", queriedFontFamily); // CSS-canonicalized
+        Assertions.assertEquals(12f, font.size());
+    }
+
+    private @NotNull PlatformSupport getSupport() {
+        Font stub = new Font(Font.DIALOG, Font.PLAIN, 1);
+        PlatformSupport support = new PlatformSupport() {
+            @Override
+            public ImageObserver imageObserver() {
+                return null;
+            }
+
+            @Override
+            public TargetSurface targetSurface() {
+                return null;
+            }
+
+            @Override
+            public @NotNull Font customFont(@NotNull String family) {
+                queriedFontFamily = family;
+                return stub;
+            }
+        };
+        return support;
     }
 
     private static @NotNull MeasurableFontSpec createFontSpec(@NotNull AttributeEntry... attributes) {

--- a/jsvg/src/testFixtures/java/com/github/weisj/jsvg/ImageComparison.java
+++ b/jsvg/src/testFixtures/java/com/github/weisj/jsvg/ImageComparison.java
@@ -64,6 +64,8 @@ import com.github.weisj.jsvg.ImageComparison.ImageSource.PathImageSource;
 import com.github.weisj.jsvg.parser.LoaderContext;
 import com.github.weisj.jsvg.parser.SVGLoader;
 import com.github.weisj.jsvg.parser.resources.ResourcePolicy;
+import com.github.weisj.jsvg.renderer.NullPlatformSupport;
+import com.github.weisj.jsvg.renderer.PlatformSupport;
 import com.github.weisj.jsvg.renderer.SVGRenderingHints;
 import com.github.weisj.jsvg.util.ColorUtil;
 import com.github.weisj.jsvg.view.FloatSize;
@@ -86,7 +88,11 @@ public final class ImageComparison {
 
         record BatikType() implements RenderType {
         }
-        record JSVGType(@NotNull LoaderContext loaderContext) implements RenderType {
+        record JSVGType(@NotNull LoaderContext loaderContext,
+                @NotNull PlatformSupport platformSupport) implements RenderType {
+            JSVGType(@NotNull LoaderContext loaderContext) {
+                this(loaderContext, NullPlatformSupport.INSTANCE);
+            }
         }
 
         record DiskImage() implements RenderType {
@@ -218,12 +224,12 @@ public final class ImageComparison {
         BufferedImage render(@Nullable BufferedImage expectedHint) throws IOException {
             return switch (renderType) {
                 case BatikType() -> renderBatik(source.openStream());
-                case JSVGType(LoaderContext loaderContext) -> {
+                case JSVGType(LoaderContext loaderContext, PlatformSupport platformSupport) -> {
                     Dimension size = null;
                     if (expectedHint != null) {
                         size = new Dimension(expectedHint.getWidth(), expectedHint.getHeight());
                     }
-                    yield renderJsvg(source, graphicsMutator, loaderContext, size);
+                    yield renderJsvg(source, graphicsMutator, loaderContext, platformSupport, size);
                 }
                 case DiskImage() -> {
                     var img = ImageIO.read(source.openStream());
@@ -368,7 +374,7 @@ public final class ImageComparison {
 
     public static @NotNull BufferedImage renderJsvg(@NotNull String path) {
         try {
-            return renderJsvg(new PathImageSource(path), null, JSVG.loaderContext(), null);
+            return renderJsvg(new PathImageSource(path), null, JSVG.loaderContext(), JSVG.platformSupport(), null);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -385,7 +391,7 @@ public final class ImageComparison {
 
     private static BufferedImage renderJsvg(@NotNull ImageSource imageSource,
             @Nullable Consumer<Graphics2D> graphicsMutator, LoaderContext loaderContext,
-            @Nullable Dimension sizeHint) throws IOException {
+            @NotNull PlatformSupport platformSupport, @Nullable Dimension sizeHint) throws IOException {
         SVGDocument document;
 
         URL url = imageSource.url();
@@ -405,7 +411,7 @@ public final class ImageComparison {
         g.setColor(ColorUtil.withAlpha(Color.WHITE, 0));
         g.fillRect(0, 0, image.getWidth(), image.getHeight());
         if (graphicsMutator != null) graphicsMutator.accept(g);
-        document.render((Component) null, g, new ViewBox(size));
+        document.renderWithPlatform(platformSupport, g, new ViewBox(size));
         g.dispose();
         return image;
     }


### PR DESCRIPTION
Adds
`default Font customFont(String family) {
        return null;
    }`
in PlatformSupport, to be overriden by clients.

System fonts for the same family name still take precedence.